### PR TITLE
test: Add form submission test for button and input submit elements

### DIFF
--- a/html/html_form_element_test.go
+++ b/html/html_form_element_test.go
@@ -234,6 +234,14 @@ var _ = Describe("HTML Form", func() {
 					button.Click()
 					Expect(submittedForm).To(HaveKey("the-button"))
 				})
+
+				It("Should include the button value in the form data if set", func() {
+					button.SetAttribute("name", "the-button")
+					button.SetAttribute("value", "the-button-value")
+					button.Click()
+					Expect(submittedForm).To(HaveKey("the-button"))
+					Expect(submittedForm.Get("the-button")).To(Equal("the-button-value"))
+				})
 			})
 
 			Describe("The button is not type='submit'", func() {

--- a/submit_form_test.go
+++ b/submit_form_test.go
@@ -1,0 +1,67 @@
+package browser
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestSubmitForm(t *testing.T) {
+	r := http.NewServeMux()
+	r.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`
+		<form action="/submit" method="post">
+			<input type="hidden" name="hidden" value="hidden-value">
+			<button name="name" value="John">John</button>
+			<input type="submit" name="name" value="Jane">Jane</button>
+		</form>
+		`))
+	})
+	r.HandleFunc("POST /submit", func(w http.ResponseWriter, r *http.Request) {
+		err := r.ParseForm()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if r.FormValue("hidden") != "hidden-value" {
+			t.Errorf("Invalid hidden value: %s", r.FormValue("hidden"))
+			http.Error(w, "Invalid hidden value", http.StatusBadRequest)
+		}
+		switch r.FormValue("name") {
+		case "John":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`<h1>Form submitted</h1>`))
+		case "Jane":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`<h1>Form submitted</h1>`))
+		default:
+			t.Errorf("Invalid name: %s", r.FormValue("name"))
+			http.Error(w, "Invalid name", http.StatusBadRequest)
+		}
+	})
+
+	b := NewFromHandler(r)
+	win, err := b.Open("http://example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := win.Document()
+	t.Run("Works for John button", func(t *testing.T) {
+		btn, err := doc.QuerySelector("button[value=John]")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !btn.Click() {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("Works for Jane input button", func(t *testing.T) {
+		btn, err := doc.QuerySelector("input[value=Jane]")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !btn.Click() {
+			t.Fatal("Failed to click button")
+		}
+	})
+}


### PR DESCRIPTION
The issue I mentioned earlier. Apparently I was wrong - it's not specific to input or button type.
It's that the input of the form are not the issue on the browser stage, but all values are lost somewhere in between.

I've made this for the purpose of showcasing the issue, this should not be merged.

```
❯ go test -run TestSubmitForm
--- FAIL: TestSubmitForm (0.01s)
    submit_form_test.go:26: Invalid hidden value: 
    submit_form_test.go:37: Invalid name: 
    submit_form_test.go:26: Invalid hidden value: 
    submit_form_test.go:37: Invalid name: 
FAIL
exit status 1
FAIL    github.com/gost-dom/browser     0.685s
``` 