### PR TITLE
feat(html): Click label forwards to "input"

### DIFF
--- a/html/html_document.go
+++ b/html/html_document.go
@@ -79,6 +79,8 @@ func (d *htmlDocument) CreateElement(name string) dom.Element {
 		return NewHTMLScriptElement(d)
 	case "a":
 		return NewHTMLAnchorElement(d)
+	case "label":
+		return NewHTMLLabelElement(d)
 	}
 	return NewHTMLElement(name, d)
 }

--- a/html/html_label_element.go
+++ b/html/html_label_element.go
@@ -1,0 +1,38 @@
+package html
+
+type HTMLLabelElement interface {
+	HTMLElement
+	HTMLFor() string
+	SetHTMLFor(string)
+}
+
+type htmlLabelElement struct {
+	htmlElement
+}
+
+func NewHTMLLabelElement(ownerDoc HTMLDocument) HTMLLabelElement {
+	result := &htmlLabelElement{
+		htmlElement: newHTMLElement("label", ownerDoc),
+	}
+	result.SetSelf(result)
+	return result
+}
+
+func (e *htmlLabelElement) HTMLFor() string {
+	f, _ := e.GetAttribute("for")
+	return f
+}
+
+func (e *htmlLabelElement) SetHTMLFor(f string) {
+	e.SetAttribute("for", f)
+}
+
+func (e *htmlLabelElement) Click() {
+	if ok := e.htmlElement.click(); !ok {
+		return
+	}
+	id := e.HTMLFor()
+	if input, _ := e.OwnerDocument().GetElementById(id).(HTMLElement); input != nil {
+		input.Click()
+	}
+}

--- a/html/html_label_element_test.go
+++ b/html/html_label_element_test.go
@@ -1,0 +1,32 @@
+package html_test
+
+import (
+	"testing"
+
+	"github.com/gost-dom/browser/dom/event"
+	"github.com/gost-dom/browser/html"
+	"github.com/gost-dom/browser/internal/testing/eventtest"
+	"github.com/gost-dom/browser/internal/testing/htmltest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTMLLabelElement(t *testing.T) {
+	var inputClicked bool
+	doc := htmltest.NewHTMLDocumentHelper(t, nil)
+	input := doc.CreateElement("input")
+	input.SetAttribute("id", "input")
+	label := doc.CreateHTMLElement("label").(html.HTMLLabelElement)
+	label.SetHTMLFor("input")
+	doc.Body().Append(input, label)
+	input.AddEventListener("click", eventtest.NewTestHandler(func(*event.Event) {
+		inputClicked = true
+	}))
+	label.Click()
+
+	assert.True(t, inputClicked, "Clicking a label should cause the input to be clicked")
+
+	inputClicked = false
+	label.AddEventListener("click", eventtest.PreventDefaultHandler())
+	label.Click()
+	assert.False(t, inputClicked, "Clicking a label should cause the input to be clicked")
+}

--- a/internal/testing/htmltest/helpers.go
+++ b/internal/testing/htmltest/helpers.go
@@ -58,6 +58,9 @@ type HTMLDocumentHelper struct {
 }
 
 func NewHTMLDocumentHelper(t testing.TB, doc dom.Document) HTMLDocumentHelper {
+	if doc == nil {
+		doc = html.NewHTMLDocument(nil)
+	}
 	return HTMLDocumentHelper{doc, t}
 }
 


### PR DESCRIPTION
When you click a `<label for="input-id">`, this corresponds to actually clicking the input element itself (if the event is not cancelled).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for label elements on web pages, enabling labels to correctly link with their associated inputs and manage click interactions.

- **Tests**
  - Added tests to verify label behavior, including attribute management and event-triggered interactions.

- **Chores**
  - Updated document initialization logic during testing to ensure the creation of valid HTML documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->