### PR TITLE
Feat/abort in js

### DIFF
--- a/internal/code-gen/customrules/dom_rules.go
+++ b/internal/code-gen/customrules/dom_rules.go
@@ -3,6 +3,9 @@ package customrules
 import "github.com/gost-dom/webref/idl"
 
 var domRules = SpecRules{
+	"AbortController": {Operations: OperationRules{
+		"abort": {Arguments: ArgumentRules{"reason": {ZeroAsDefault: true}}},
+	}},
 	"AbortSignal": {Operations: OperationRules{
 		"throwIfAborted": {HasError: true},
 	}},

--- a/internal/code-gen/scripting/configuration/dom_configuration.go
+++ b/internal/code-gen/scripting/configuration/dom_configuration.go
@@ -9,8 +9,7 @@ func ConfigureDOMSpecs(specs *WebIdlConfigurations) {
 func configureDOMNode(specs *WebAPIConfig) {
 	configureMutationObserver(specs)
 
-	abortCtrl := specs.Type("AbortController")
-	abortCtrl.MarkMembersAsNotImplemented("abort")
+	specs.Type("AbortController")
 	abortSignal := specs.Type("AbortSignal")
 	abortSignal.MarkMembersAsNotImplemented("reason")
 

--- a/internal/code-gen/scripting/op_callback_methods.go
+++ b/internal/code-gen/scripting/op_callback_methods.go
@@ -150,6 +150,9 @@ func (gen OpCallbackMethods) CtorOrOperationCallback(
 }
 
 func (gen OpCallbackMethods) DefaultValuer(a model.ESOperationArgument) (g.Generator, bool) {
+	if a.CustomRule.ZeroAsDefault {
+		return zeroValue, true
+	}
 	switch a.IdlArg.Type.Name {
 	case "EventInit", "HTMLElement":
 		return zeroValue, true

--- a/internal/dom/abort_controller.go
+++ b/internal/dom/abort_controller.go
@@ -2,7 +2,6 @@ package dom
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/gost-dom/browser/dom/event"
 	"github.com/gost-dom/browser/internal/promise"
@@ -60,7 +59,6 @@ func AbortContext(ctx context.Context, signal *AbortSignal) context.Context {
 			if !ok {
 				err = promise.ErrAny{Reason: reason}
 			}
-			fmt.Printf("Cancelling with reason (%p): %v\n", signal, err)
 			cancel(err)
 		case <-ctx.Done():
 			cancel(nil)

--- a/internal/dom/abort_controller.go
+++ b/internal/dom/abort_controller.go
@@ -41,7 +41,7 @@ func (s AbortSignal) Onabort() event.EventHandler   { return nil }
 func (s AbortSignal) SetOnabort(event.EventHandler) {}
 func (s AbortSignal) ThrowIfAborted() error         { return nil }
 
-// AbortContext will listen to abort events from an [EventSignal]. The return
+// AbortContext will listen to abort events from an [AbortSignal]. The return
 // value is a child context of ctx which will be cancelled if a, abort event is
 // dispatched before the parent context cancels.
 //

--- a/internal/dom/abort_controller.go
+++ b/internal/dom/abort_controller.go
@@ -42,9 +42,9 @@ func (s AbortSignal) Onabort() event.EventHandler   { return nil }
 func (s AbortSignal) SetOnabort(event.EventHandler) {}
 func (s AbortSignal) ThrowIfAborted() error         { return nil }
 
-// AbortContext will listen to abort events from an [event.EventTarget]. The
-// return value is a child context of ctx which will be cancelled if a, abort
-// event is dispatched before the parent context cancels.
+// AbortContext will listen to abort events from an [EventSignal]. The return
+// value is a child context of ctx which will be cancelled if a, abort event is
+// dispatched before the parent context cancels.
 //
 // If the context is cancelled due to an abort event, the abort reason can be
 // used as the cancel cause, which can be read using [context.Cause]. If the
@@ -55,7 +55,6 @@ func AbortContext(ctx context.Context, signal *AbortSignal) context.Context {
 	go func() {
 		select {
 		case <-abortEvents:
-
 			reason := signal.reason
 			err, ok := reason.(error)
 			if !ok {

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gost-dom/browser/html"
 	"github.com/gost-dom/browser/internal/dom"
-	dominterfaces "github.com/gost-dom/browser/internal/interfaces/dom-interfaces"
 	"github.com/gost-dom/browser/internal/log"
 	"github.com/gost-dom/browser/internal/promise"
 	"github.com/gost-dom/browser/url"
@@ -35,7 +34,7 @@ type RequestOption func(*Request)
 type Request struct {
 	url    string
 	bc     html.BrowsingContext
-	signal dominterfaces.AbortSignal
+	signal *dom.AbortSignal
 }
 
 func (r *Request) URL() string { return url.ParseURLBase(r.url, r.bc.LocationHREF()).Href() }
@@ -52,7 +51,7 @@ func (r *Request) do(ctx context.Context) (*http.Response, error) {
 	return c.Do(req)
 }
 
-func WithSignal(s dominterfaces.AbortSignal) RequestOption {
+func WithSignal(s *dom.AbortSignal) RequestOption {
 	return func(opt *Request) { opt.signal = s }
 }
 

--- a/internal/fetch/fetch_test.go
+++ b/internal/fetch/fetch_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gost-dom/browser/internal/dom"
 	"github.com/gost-dom/browser/internal/fetch"
+	"github.com/gost-dom/browser/internal/promise"
 	"github.com/gost-dom/browser/internal/testing/gosttest"
 	"github.com/stretchr/testify/assert"
 )
@@ -71,10 +72,14 @@ func TestFetchAborted(t *testing.T) {
 			assert.Equal(t, 200, res.Value.Status)
 			assert.NoError(t, res.Err, "response error")
 
+			t.Log("Reason before", ac.Signal().Reason())
 			ac.Abort("Dummy reason")
+			t.Logf("Reason after (%p): %v", ac.Signal(), ac.Signal().Reason())
 
 			_, err := io.ReadAll(res.Value.Reader)
-			assert.Error(t, err, "reading response body of cancelled response")
+			var errAny promise.ErrAny
+			assert.ErrorAs(t, err, &errAny, "reading response body of cancelled response")
+			assert.Equal(t, "Dummy reason", errAny.Reason, "Error reason")
 		})
 	})
 }

--- a/internal/fetch/fetch_test.go
+++ b/internal/fetch/fetch_test.go
@@ -78,6 +78,7 @@ func TestFetchAborted(t *testing.T) {
 
 			_, err := io.ReadAll(res.Value.Reader)
 			var errAny promise.ErrAny
+			t.Logf("Error: %#v", err)
 			assert.ErrorAs(t, err, &errAny, "reading response body of cancelled response")
 			assert.Equal(t, "Dummy reason", errAny.Reason, "Error reason")
 		})

--- a/internal/promise/promise.go
+++ b/internal/promise/promise.go
@@ -53,3 +53,11 @@ type ErrAny struct{ Reason any }
 func (err ErrAny) Error() string {
 	return fmt.Sprintf("aborted: reason: %v", err.Reason)
 }
+
+func (err ErrAny) As(target any) bool {
+	if errAny, ok := target.(*ErrAny); ok {
+		*errAny = err
+		return true
+	}
+	return false
+}

--- a/internal/test/scripttests/fetch_suite.go
+++ b/internal/test/scripttests/fetch_suite.go
@@ -40,6 +40,7 @@ func (s *FetchSuite) TestPrototypes() {
 
 type option struct {
 	logOptions []gosttest.TestLoggerOption
+	ctx        context.Context
 }
 
 type InitOption func(*option)
@@ -50,6 +51,10 @@ func WithLogOption(lo gosttest.TestLoggerOption) InitOption {
 
 func WithMinLogLevel(lvl slog.Level) InitOption {
 	return WithLogOption(gosttest.MinLogLevel(lvl))
+}
+
+func WithContext(ctx context.Context) InitOption {
+	return func(o *option) { o.ctx = ctx }
 }
 
 func initWindow(
@@ -63,7 +68,12 @@ func initWindow(
 		opt(&o)
 	}
 	logger := gosttest.NewTestLogger(t, o.logOptions...)
+	ctx := o.ctx
+	if ctx == nil {
+		ctx = t.Context()
+	}
 	b := htmltest.NewBrowserHelper(t, browser.New(
+		browser.WithContext(ctx),
 		browser.WithLogger(logger),
 		browser.WithHandler(h),
 		browser.WithScriptHost(host),

--- a/scripting/gojahost/goja_context.go
+++ b/scripting/gojahost/goja_context.go
@@ -45,6 +45,16 @@ func (i *GojaContext) Run(str string) error {
 
 func (i *GojaContext) Eval(str string) (res any, err error) {
 	if gojaVal, err := i.run(str); err == nil {
+		if goja.IsNull(gojaVal) || goja.IsUndefined(gojaVal) {
+			return nil, nil
+		}
+		if obj := gojaVal.ToObject(i.vm); obj != nil {
+			if v := obj.GetSymbol(i.wrappedGoObj); v != nil {
+				if e := v.Export(); e != nil {
+					return e, nil
+				}
+			}
+		}
 		return gojaVal.Export(), nil
 	} else {
 		return nil, err

--- a/scripting/gojahost/goja_error.go
+++ b/scripting/gojahost/goja_error.go
@@ -1,0 +1,13 @@
+package gojahost
+
+import "github.com/gost-dom/browser/scripting/internal/js"
+
+type gojaError struct {
+	js.Value[jsTypeParam]
+	error
+}
+
+func newGojaError(ctx *GojaContext, err error) js.Error[jsTypeParam] {
+	obj := newGojaObject(ctx, ctx.vm.NewGoError(err))
+	return gojaError{obj, err}
+}

--- a/scripting/gojahost/goja_promise.go
+++ b/scripting/gojahost/goja_promise.go
@@ -18,9 +18,5 @@ func newGojaPromise(ctx *GojaContext) gojaPromise {
 	}
 }
 
-func (p gojaPromise) Resolve(value js.Value[jsTypeParam])     { p.resolve(value.Self().value) }
-func (p gojaPromise) RejectValue(value js.Value[jsTypeParam]) { p.reject(value.Self().value) }
-
-func (p gojaPromise) Reject(err error) {
-	p.reject(p.Self().ctx.vm.NewGoError(err))
-}
+func (p gojaPromise) Resolve(value js.Value[jsTypeParam]) { p.resolve(value.Self().value) }
+func (p gojaPromise) Reject(value js.Value[jsTypeParam])  { p.reject(value.Self().value) }

--- a/scripting/gojahost/goja_promise.go
+++ b/scripting/gojahost/goja_promise.go
@@ -18,9 +18,8 @@ func newGojaPromise(ctx *GojaContext) gojaPromise {
 	}
 }
 
-func (p gojaPromise) Resolve(value js.Value[jsTypeParam]) {
-	p.resolve(value.Self().value)
-}
+func (p gojaPromise) Resolve(value js.Value[jsTypeParam])     { p.resolve(value.Self().value) }
+func (p gojaPromise) RejectValue(value js.Value[jsTypeParam]) { p.reject(value.Self().value) }
 
 func (p gojaPromise) Reject(err error) {
 	p.reject(p.Self().ctx.vm.NewGoError(err))

--- a/scripting/gojahost/goja_scope.go
+++ b/scripting/gojahost/goja_scope.go
@@ -84,6 +84,10 @@ func (f gojaScope) NewBoolean(v bool) js.Value[jsTypeParam] {
 	return newGojaValue(f.GojaContext, f.vm.ToValue(v))
 }
 
+func (f gojaScope) Undefined() js.Value[jsTypeParam] {
+	return newGojaValue(f.GojaContext, goja.Undefined())
+}
+
 func (f gojaScope) Null() js.Value[jsTypeParam] {
 	return newGojaValue(f.GojaContext, goja.Null())
 }
@@ -109,6 +113,10 @@ func (f gojaScope) NewTypeError(v string) error {
 }
 
 func (c gojaScope) NewPromise() js.Promise[jsTypeParam] { return newGojaPromise(c.GojaContext) }
+
+func (c gojaScope) NewError(err error) js.Error[jsTypeParam] {
+	return newGojaError(c.GojaContext, err)
+}
 
 func (f gojaScope) NewIterator(
 	items iter.Seq2[js.Value[jsTypeParam], error],

--- a/scripting/internal/codec/encoders.go
+++ b/scripting/internal/codec/encoders.go
@@ -100,11 +100,14 @@ func EncodePromiseFunc[T any](
 	e := c.Clock().BeginEvent()
 	go func() {
 		r, err := f()
-		e.AddSafeEvent(func() {
+		e.AddEvent(func() error {
 			if err == nil {
 				p.Resolve(r)
+				return nil
 			} else {
-				p.Reject(err)
+				jsErr, err := EncodeError(c, err)
+				p.Reject(jsErr)
+				return err
 			}
 		})
 	}()
@@ -143,7 +146,7 @@ func EncodePromise[T, U any](
 				if errVal == nil {
 					errVal = scope.Undefined()
 				}
-				p.RejectValue(errVal)
+				p.Reject(errVal)
 				return err
 			}
 		})

--- a/scripting/internal/dom/abort_controller.go
+++ b/scripting/internal/dom/abort_controller.go
@@ -24,9 +24,5 @@ func (w AbortController[T]) toAbortSignal(
 	cbCtx js.CallbackContext[T],
 	signal dominterfaces.AbortSignal,
 ) (js.Value[T], error) {
-	instance, err := js.As[dominterfaces.AbortController](cbCtx.Instance())
-	if err != nil {
-		return nil, err
-	}
-	return cbCtx.Constructor("AbortSignal").NewInstance(instance.Signal())
+	return cbCtx.Constructor("AbortSignal").NewInstance(signal)
 }

--- a/scripting/internal/dom/abort_controller.go
+++ b/scripting/internal/dom/abort_controller.go
@@ -26,3 +26,7 @@ func (w AbortController[T]) toAbortSignal(
 ) (js.Value[T], error) {
 	return cbCtx.Constructor("AbortSignal").NewInstance(signal)
 }
+
+func (w AbortController[T]) decodeAny(_ js.CallbackContext[T], v js.Value[T]) (js.Value[T], error) {
+	return v, nil
+}

--- a/scripting/internal/dom/abort_controller_generated.go
+++ b/scripting/internal/dom/abort_controller_generated.go
@@ -3,8 +3,8 @@
 package dom
 
 import (
-	"errors"
 	dominterfaces "github.com/gost-dom/browser/internal/interfaces/dom-interfaces"
+	codec "github.com/gost-dom/browser/scripting/internal/codec"
 	js "github.com/gost-dom/browser/scripting/internal/js"
 )
 
@@ -30,7 +30,16 @@ func (w AbortController[T]) Constructor(cbCtx js.CallbackContext[T]) (js.Value[T
 
 func (w AbortController[T]) abort(cbCtx js.CallbackContext[T]) (js.Value[T], error) {
 	cbCtx.Logger().Debug("V8 Function call: AbortController.abort")
-	return nil, errors.New("AbortController.abort: Not implemented. Create an issue: https://github.com/gost-dom/browser/issues")
+	instance, errInst := js.As[dominterfaces.AbortController](cbCtx.Instance())
+	if errInst != nil {
+		return nil, errInst
+	}
+	reason, errArg1 := js.ConsumeArgument(cbCtx, "reason", codec.ZeroValue, w.decodeAny)
+	if errArg1 != nil {
+		return nil, errArg1
+	}
+	instance.Abort(reason)
+	return nil, nil
 }
 
 func (w AbortController[T]) signal(cbCtx js.CallbackContext[T]) (js.Value[T], error) {

--- a/scripting/internal/fetch/fetch.go
+++ b/scripting/internal/fetch/fetch.go
@@ -1,6 +1,7 @@
 package fetch
 
 import (
+	"github.com/gost-dom/browser/internal/dom"
 	"github.com/gost-dom/browser/internal/fetch"
 	"github.com/gost-dom/browser/scripting/internal/codec"
 	"github.com/gost-dom/browser/scripting/internal/js"
@@ -15,8 +16,35 @@ func Fetch[T any](info js.CallbackContext[T]) (js.Value[T], error) {
 	if err != nil {
 		return nil, err
 	}
+	opts, err := js.ConsumeArgument(info, "options", defaultRequestOptions, decodeRequestOptions)
 	f := fetch.New(info.Window())
 	info.Logger().Debug("js/fetch: create promise")
-	req := f.NewRequest(url)
+	req := f.NewRequest(url, opts...)
 	return codec.EncodePromise(info, f.FetchAsync(req), encodeResponse)
+}
+
+func defaultRequestOptions() []fetch.RequestOption { return nil }
+
+func decodeRequestOptions[T any](
+	ctx js.CallbackContext[T],
+	val js.Value[T],
+) (opts []fetch.RequestOption, err error) {
+	obj, ok := val.AsObject()
+	if !ok {
+		return nil, nil
+	}
+	var f js.Value[T]
+	if f, err = obj.Get("signal"); err != nil {
+		return
+	}
+	fobj, ok := f.AsObject()
+	signal, err := js.As[*dom.AbortSignal](fobj.NativeValue(), nil)
+	if err != nil {
+		return nil, err
+	}
+	if signal != nil {
+		ctx.Logger().Debug("ADD Signal", "signal", signal)
+		opts = append(opts, fetch.WithSignal(signal))
+	}
+	return
 }

--- a/scripting/internal/js/callback_context.go
+++ b/scripting/internal/js/callback_context.go
@@ -136,6 +136,7 @@ func WithEnumeratorCallback[T, U any](cb HandlerEnumeratorCallback[T, U]) Handle
 
 // ValueFactory allows creating JavaScript values from Go values
 type ValueFactory[T any] interface {
+	Undefined() Value[T]
 	Null() Value[T]
 
 	NewPromise() Promise[T]
@@ -155,6 +156,14 @@ type ValueFactory[T any] interface {
 
 	NewTypeError(msg string) error
 
+	NewError(err error) Error[T]
+
 	JSONStringify(val Value[T]) string
 	JSONParse(val string) (Value[T], error)
+}
+
+// Error is a JavaScript representation of a go error instance.
+type Error[T any] interface {
+	Value[T]
+	error
 }

--- a/scripting/internal/js/value.go
+++ b/scripting/internal/js/value.go
@@ -99,4 +99,5 @@ type Promise[T any] interface {
 	// to only use Error values, and this assumes that all API calls will follow
 	// this practice.
 	Reject(error)
+	RejectValue(Value[T])
 }

--- a/scripting/internal/js/value.go
+++ b/scripting/internal/js/value.go
@@ -98,6 +98,5 @@ type Promise[T any] interface {
 	// So while you can reject with any value in JavaScript, it is best practice
 	// to only use Error values, and this assumes that all API calls will follow
 	// this practice.
-	Reject(error)
-	RejectValue(Value[T])
+	Reject(Value[T])
 }

--- a/scripting/v8host/callback_context.go
+++ b/scripting/v8host/callback_context.go
@@ -109,6 +109,7 @@ func (s v8Scope) GlobalThis() jsObject { return s.global }
 func (s v8Scope) Clock() *clock.Clock  { return s.clock }
 
 func (f v8Scope) iso() *v8go.Isolate { return f.host.iso }
+func (f v8Scope) Undefined() jsValue { return f.toJSValue(v8go.Undefined(f.iso())) }
 func (f v8Scope) Null() jsValue      { return f.toJSValue(v8go.Null(f.iso())) }
 
 func (f v8Scope) NewString(val string) jsValue { return f.newV8Value(val) }
@@ -118,6 +119,12 @@ func (f v8Scope) NewInt64(val int64) jsValue   { return f.newV8Value(val) }
 func (f v8Scope) NewBoolean(val bool) jsValue  { return f.newV8Value(val) }
 func (s v8Scope) NewPromise() js.Promise[jsTypeParam] {
 	return newV8Promise(s.V8ScriptContext)
+}
+
+func (s v8Scope) NewError(
+	err error,
+) js.Error[jsTypeParam] {
+	return newV8Error(s.V8ScriptContext, err)
 }
 
 func (f v8Scope) JSONStringify(val jsValue) string {

--- a/scripting/v8host/v8_error.go
+++ b/scripting/v8host/v8_error.go
@@ -1,0 +1,17 @@
+package v8host
+
+import (
+	"github.com/gost-dom/browser/scripting/internal/js"
+	"github.com/gost-dom/v8go"
+)
+
+type V8Error struct {
+	*v8Value
+	error
+}
+
+func newV8Error(ctx *V8ScriptContext, err error) js.Error[jsTypeParam] {
+	exc := v8go.NewError(ctx.iso(), err.Error())
+	val := &v8Value{ctx, exc.Value}
+	return &V8Error{val, err}
+}

--- a/scripting/v8host/v8_promise.go
+++ b/scripting/v8host/v8_promise.go
@@ -19,7 +19,9 @@ func newV8Promise(ctx *V8ScriptContext) v8Promise {
 	return v8Promise{newV8Value(ctx, promise.GetPromise().Value), promise}
 }
 
-func (p v8Promise) Resolve(val jsValue) { p.PromiseResolver.Resolve(val.Self().Value) }
+func (p v8Promise) Resolve(val jsValue)     { p.PromiseResolver.Resolve(val.Self().Value) }
+func (p v8Promise) RejectValue(val jsValue) { p.PromiseResolver.Reject(val.Self().Value) }
+
 func (p v8Promise) Reject(err error) {
 	v8err := v8go.NewError(p.Self().iso(), err.Error())
 	p.PromiseResolver.Reject(v8err.Value)

--- a/scripting/v8host/v8_promise.go
+++ b/scripting/v8host/v8_promise.go
@@ -19,10 +19,5 @@ func newV8Promise(ctx *V8ScriptContext) v8Promise {
 	return v8Promise{newV8Value(ctx, promise.GetPromise().Value), promise}
 }
 
-func (p v8Promise) Resolve(val jsValue)     { p.PromiseResolver.Resolve(val.Self().Value) }
-func (p v8Promise) RejectValue(val jsValue) { p.PromiseResolver.Reject(val.Self().Value) }
-
-func (p v8Promise) Reject(err error) {
-	v8err := v8go.NewError(p.Self().iso(), err.Error())
-	p.PromiseResolver.Reject(v8err.Value)
-}
+func (p v8Promise) Resolve(val jsValue) { p.PromiseResolver.Resolve(val.Self().Value) }
+func (p v8Promise) Reject(val jsValue)  { p.PromiseResolver.Reject(val.Self().Value) }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full support for aborting fetch requests using the AbortController and AbortSignal APIs, including passing custom abort reasons.
  * Enhanced error handling: abort reasons are now correctly propagated and surfaced in fetch promise rejections.
  * Improved JavaScript integration by allowing Go errors to be converted into JavaScript error objects in both Goja and V8 environments.

* **Bug Fixes**
  * Fetch requests now properly recognize and handle abort signals, ensuring correct cancellation behavior and error reporting.

* **Tests**
  * Added comprehensive tests for aborting fetch requests and verifying abort reasons in both Go and JavaScript environments.

* **Refactor**
  * Streamlined internal error and signal handling, and improved API consistency for promise rejection and error creation across scripting engines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->