### PR TITLE
feat: Expose ParentNode.children to JS

### DIFF
--- a/dom/html_collection.go
+++ b/dom/html_collection.go
@@ -1,11 +1,18 @@
 package dom
 
+type HTMLCollection interface {
+	All() []Element
+	Length() int
+	Item(int) Element
+	NamedItem(string) Element
+}
+
 // htmlCollection provides an implementation for [HTMLCollection].
 type htmlCollection struct{ node Node }
 
 func newHtmlCollection(n Node) HTMLCollection { return htmlCollection{n} }
 
-func (c htmlCollection) elements() []Element {
+func (c htmlCollection) All() []Element {
 	nodes := c.node.ChildNodes().All()
 	res := make([]Element, 0, len(nodes))
 	for _, n := range nodes {
@@ -17,11 +24,11 @@ func (c htmlCollection) elements() []Element {
 }
 
 func (c htmlCollection) Length() int {
-	return len(c.elements())
+	return len(c.All())
 }
 
 func (c htmlCollection) Item(i int) Element {
-	es := c.elements()
+	es := c.All()
 	if i < 0 || i >= len(es) {
 		return nil
 	}
@@ -29,7 +36,7 @@ func (c htmlCollection) Item(i int) Element {
 }
 
 func (c htmlCollection) NamedItem(name string) Element {
-	for _, e := range c.elements() {
+	for _, e := range c.All() {
 		if id, hasId := e.GetAttribute("id"); hasId && id == name {
 			return e
 		}

--- a/dom/html_collection_generated.go
+++ b/dom/html_collection_generated.go
@@ -1,9 +1,0 @@
-// This file is generated. Do not edit.
-
-package dom
-
-type HTMLCollection interface {
-	Length() int
-	Item(int) Element
-	NamedItem(string) Element
-}

--- a/internal/code-gen/html-elements/dom_generator_test.go
+++ b/internal/code-gen/html-elements/dom_generator_test.go
@@ -21,6 +21,9 @@ func (s *DomSuite) SetupTest() {
 }
 
 func (s *DomSuite) TestGenerateHTMLCollection() {
+	s.T().Skip(
+		"HTMLCollection is not generated currently, as it doesn't generate an All() function",
+	)
 	generator, err := getIdlInterfaceGenerator("dom", "HTMLCollection")
 	s.Expect(err).ToNot(HaveOccurred())
 	s.Expect(generator).To(HaveRendered(ContainSubstring(`Length() int`)))

--- a/internal/code-gen/html-elements/dom_generators.go
+++ b/internal/code-gen/html-elements/dom_generators.go
@@ -11,11 +11,13 @@ var DOMPackageConfig = GeneratorConfig{
 		SpecName:          "dom",
 		GenerateInterface: true,
 	},
+	/* Doesn't generate an All() function
 	"html_collection": {
 		InterfaceName:     "HTMLCollection",
 		SpecName:          "dom",
 		GenerateInterface: true,
 	},
+	*/
 }
 
 func CreateDOMGenerators() ([]FileGeneratorSpec, error) {

--- a/internal/code-gen/scripting/configuration/dom_configuration.go
+++ b/internal/code-gen/scripting/configuration/dom_configuration.go
@@ -73,8 +73,10 @@ func configureDOMNode(specs *WebAPIConfig) {
 	nodeList := specs.Type("NodeList")
 	nodeList.RunCustomCode = true
 
+	htmlCollection := specs.Type("HTMLCollection")
+	htmlCollection.RunCustomCode = true
+
 	parentNode := specs.Type("ParentNode")
-	parentNode.Method("children").Ignore()
 	parentNode.Method("append").Argument("nodes").Decoder = "w.decodeNodeOrText"
 	parentNode.Method("prepend").Argument("nodes").Decoder = "w.decodeNodeOrText"
 	parentNode.Method("replaceChildren").Argument("nodes").Decoder = "w.decodeNodeOrText"

--- a/internal/test/scripttests/element_suite.go
+++ b/internal/test/scripttests/element_suite.go
@@ -41,7 +41,39 @@ func (s *ElementSuite) TestIDLInterfaceNamesForElements() {
 	s.Expect("document.createElement('a')").To(BeJSInstanceOf("HTMLAnchorElement", ctx))
 	s.Expect("document.createElement('p')").To(BeJSInstanceOf("HTMLParagraphElement", ctx))
 	s.Expect("document.createElement('div')").To(BeJSInstanceOf("HTMLDivElement", ctx))
+}
 
+func (s *ElementSuite) TestChildren() {
+	s.MustLoadHTML(`
+		<body>
+			<div id="target">
+				Initial text
+				<div id="child-1">Child 1</div>
+				Some text
+				<div id="child-2">Child 2</div>
+				Final text
+			</div>
+		</body>`,
+	)
+	s.MustRunScript(`
+		const target = document.getElementById("target")
+		const child1ByItem = target.children.item(0)
+		const child1ByIndex = target.children[0]
+		const child2ByItem = target.children.item(1)
+		const child2ByIndex = target.children[1]
+		const length = target.children.length
+		const arr = Array.from(target.children)
+		const contents = arr.map(x => x.getAttribute("id")).join(",")
+	`)
+	assert := s.Assert()
+	assert.Equal("Child 1", s.MustEval("child1ByItem.textContent"))
+	assert.Equal("Child 1", s.MustEval("child1ByIndex.textContent"))
+	assert.Equal("Child 2", s.MustEval("child2ByItem.textContent"))
+	assert.Equal("Child 2", s.MustEval("child2ByIndex.textContent"))
+
+	s.Expect(s.MustEval("length")).To(BeEquivalentTo(2))
+
+	assert.Equal("child-1,child-2", s.MustEval("contents"))
 }
 
 type BeJSInstanceOfMatcher struct {

--- a/scripting/internal/dom/html_collection.go
+++ b/scripting/internal/dom/html_collection.go
@@ -1,0 +1,40 @@
+package dom
+
+import (
+	"github.com/gost-dom/browser/dom"
+	"github.com/gost-dom/browser/scripting/internal/codec"
+	"github.com/gost-dom/browser/scripting/internal/js"
+)
+
+func (w *HTMLCollection[T]) CustomInitializer(class js.Class[T]) {
+	nodeListIterator := js.NewIterator(
+		func(ctx js.Scope[T], instance dom.Element) (js.Value[T], error) {
+			return codec.EncodeEntityScoped(ctx, instance)
+		})
+	nodeListIterator.InstallPrototype(class)
+
+	class.CreateIndexedHandler(
+		js.WithIndexedGetterCallback(
+			func(info js.CallbackScope[T], index int) (js.Value[T], error) {
+				instance := info.This().NativeValue()
+				if nodemap, ok := instance.(dom.HTMLCollection); ok {
+					item := nodemap.Item(index)
+					if item == nil {
+						return nil, nil
+					}
+					return codec.EncodeEntity(info, item)
+				}
+				return nil, info.NewTypeError("dunno")
+			},
+		),
+		js.WithLengthCallback(
+			func(cbCtx js.CallbackScope[T]) (int, error) {
+				instance, err := js.As[dom.HTMLCollection](cbCtx.Instance())
+				if err != nil {
+					return 0, err
+				}
+				return instance.Length(), nil
+			},
+		),
+	)
+}

--- a/scripting/internal/dom/html_collection_generated.go
+++ b/scripting/internal/dom/html_collection_generated.go
@@ -1,0 +1,69 @@
+// This file is generated. Do not edit.
+
+package dom
+
+import (
+	dom "github.com/gost-dom/browser/dom"
+	codec "github.com/gost-dom/browser/scripting/internal/codec"
+	js "github.com/gost-dom/browser/scripting/internal/js"
+)
+
+type HTMLCollection[T any] struct{}
+
+func NewHTMLCollection[T any](scriptHost js.ScriptEngine[T]) *HTMLCollection[T] {
+	return &HTMLCollection[T]{}
+}
+
+func (wrapper HTMLCollection[T]) Initialize(jsClass js.Class[T]) {
+	wrapper.installPrototype(jsClass)
+	wrapper.CustomInitializer(jsClass)
+}
+
+func (w HTMLCollection[T]) installPrototype(jsClass js.Class[T]) {
+	jsClass.CreatePrototypeMethod("item", w.item)
+	jsClass.CreatePrototypeMethod("namedItem", w.namedItem)
+	jsClass.CreatePrototypeAttribute("length", w.length, nil)
+}
+
+func (w HTMLCollection[T]) Constructor(cbCtx js.CallbackContext[T]) (js.Value[T], error) {
+	cbCtx.Logger().Debug("JS Function call: HTMLCollection.Constructor")
+	return cbCtx.ReturnWithTypeError("Illegal constructor")
+}
+
+func (w HTMLCollection[T]) item(cbCtx js.CallbackContext[T]) (js.Value[T], error) {
+	cbCtx.Logger().Debug("JS Function call: HTMLCollection.item")
+	instance, errInst := js.As[dom.HTMLCollection](cbCtx.Instance())
+	if errInst != nil {
+		return nil, errInst
+	}
+	index, errArg1 := js.ConsumeArgument(cbCtx, "index", nil, codec.DecodeInt)
+	if errArg1 != nil {
+		return nil, errArg1
+	}
+	result := instance.Item(index)
+	return codec.EncodeEntity(cbCtx, result)
+}
+
+func (w HTMLCollection[T]) namedItem(cbCtx js.CallbackContext[T]) (js.Value[T], error) {
+	cbCtx.Logger().Debug("JS Function call: HTMLCollection.namedItem")
+	instance, errInst := js.As[dom.HTMLCollection](cbCtx.Instance())
+	if errInst != nil {
+		return nil, errInst
+	}
+	name, errArg1 := js.ConsumeArgument(cbCtx, "name", nil, codec.DecodeString)
+	if errArg1 != nil {
+		return nil, errArg1
+	}
+	result := instance.NamedItem(name)
+	return codec.EncodeEntity(cbCtx, result)
+}
+
+func (w HTMLCollection[T]) length(cbCtx js.CallbackContext[T]) (js.Value[T], error) {
+	cbCtx.Logger().Debug("JS Function call: HTMLCollection.length")
+	instance, err := js.As[dom.HTMLCollection](cbCtx.Instance())
+	if err != nil {
+		return nil, err
+	}
+	result := instance.Length()
+	return codec.EncodeInt(cbCtx, result)
+}

--- a/scripting/internal/dom/node_list.go
+++ b/scripting/internal/dom/node_list.go
@@ -16,15 +16,14 @@ func (w *NodeList[T]) CustomInitializer(class js.Class[T]) {
 	class.CreateIndexedHandler(
 		js.WithIndexedGetterCallback(
 			func(info js.CallbackScope[T], index int) (js.Value[T], error) {
-				instance := info.This().NativeValue()
-				if nodemap, ok := instance.(dom.NodeList); ok {
-					item := nodemap.Item(index)
-					if item == nil {
-						return nil, nil
-					}
+				instance, err := js.As[dom.NodeList](info.Instance())
+				if err != nil {
+					return nil, err
+				}
+				if item := instance.Item(index); item != nil {
 					return codec.EncodeEntity(info, item)
 				}
-				return nil, info.NewTypeError("dunno")
+				return nil, nil
 			},
 		),
 		js.WithLengthCallback(

--- a/scripting/internal/dom/parent_node.go
+++ b/scripting/internal/dom/parent_node.go
@@ -1,0 +1,13 @@
+package dom
+
+import (
+	dom "github.com/gost-dom/browser/dom"
+	js "github.com/gost-dom/browser/scripting/internal/js"
+)
+
+func (w ParentNode[T]) toHTMLCollection(
+	ctx js.CallbackContext[T],
+	c dom.HTMLCollection,
+) (js.Value[T], error) {
+	return ctx.Constructor("HTMLCollection").NewInstance(c)
+}

--- a/scripting/internal/dom/parent_node_generated.go
+++ b/scripting/internal/dom/parent_node_generated.go
@@ -24,6 +24,7 @@ func (w ParentNode[T]) installPrototype(jsClass js.Class[T]) {
 	jsClass.CreatePrototypeMethod("replaceChildren", w.replaceChildren)
 	jsClass.CreatePrototypeMethod("querySelector", w.querySelector)
 	jsClass.CreatePrototypeMethod("querySelectorAll", w.querySelectorAll)
+	jsClass.CreatePrototypeAttribute("children", w.children, nil)
 	jsClass.CreatePrototypeAttribute("firstElementChild", w.firstElementChild, nil)
 	jsClass.CreatePrototypeAttribute("lastElementChild", w.lastElementChild, nil)
 	jsClass.CreatePrototypeAttribute("childElementCount", w.childElementCount, nil)
@@ -108,6 +109,16 @@ func (w ParentNode[T]) querySelectorAll(cbCtx js.CallbackContext[T]) (js.Value[T
 		return nil, errCall
 	}
 	return codec.EncodeEntity(cbCtx, result)
+}
+
+func (w ParentNode[T]) children(cbCtx js.CallbackContext[T]) (js.Value[T], error) {
+	cbCtx.Logger().Debug("JS Function call: ParentNode.children")
+	instance, err := js.As[dom.ParentNode](cbCtx.Instance())
+	if err != nil {
+		return nil, err
+	}
+	result := instance.Children()
+	return w.toHTMLCollection(cbCtx, result)
 }
 
 func (w ParentNode[T]) firstElementChild(cbCtx js.CallbackContext[T]) (js.Value[T], error) {

--- a/scripting/internal/dom/register_generated.go
+++ b/scripting/internal/dom/register_generated.go
@@ -14,6 +14,7 @@ func Bootstrap[T any](reg js.ClassBuilder[T]) {
 	js.RegisterClass(reg, "Element", "Node", NewElement)
 	js.RegisterClass(reg, "Event", "", NewEvent)
 	js.RegisterClass(reg, "EventTarget", "", NewEventTarget)
+	js.RegisterClass(reg, "HTMLCollection", "", NewHTMLCollection)
 	js.RegisterClass(reg, "MutationObserver", "", NewMutationObserver)
 	js.RegisterClass(reg, "MutationRecord", "", NewMutationRecord)
 	js.RegisterClass(reg, "NamedNodeMap", "", NewNamedNodeMap)


### PR DESCRIPTION
Chilren() was implemented in the Go DOM - but not exposed to JS