### PR TITLE
refactor: Remove unnecessary log calls

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -224,7 +224,7 @@ func (b *Browser) createOptions(location string) WindowOptions {
 // Note: If a browser is initialized by passing a [context.Context] to the
 // [WithContext] option, it will be closed if the context is cancelled.
 func (b *Browser) Close() {
-	log.Debug(b.Logger, "Browser: Close()")
+	b.logger().Info("Browser: Close()")
 	for _, win := range b.windows {
 		win.Close()
 	}
@@ -235,3 +235,10 @@ func (b *Browser) Close() {
 }
 
 func (b *Browser) Closed() bool { return b.closed }
+
+func (b *Browser) logger() *slog.Logger {
+	if b.Logger != nil {
+		return b.Logger
+	}
+	return log.Default()
+}

--- a/dom/node.go
+++ b/dom/node.go
@@ -235,7 +235,7 @@ func (n *node) cloneChildren() []Node {
 //
 // [MDN docs for appendChild]: https://developer.mozilla.org/en-US/docs/Web/API/Node/appendChild
 func (n *node) AppendChild(node Node) (Node, error) {
-	log.Debug(n.Logger(), "Node.AppendChild", "target", n.String(), "child", node.NodeName())
+	n.Logger().Debug("Node.AppendChild", "target", n.String(), "child", node.NodeName())
 	_, err := n.self.InsertBefore(node, nil)
 	return node, err
 }
@@ -284,7 +284,7 @@ func (n *node) removeObserver(o observer) {
 
 func (n *node) GetRootNode(options ...GetRootNodeOptions) Node {
 	if len(options) > 1 {
-		log.Warn(n.Logger(), "Node.GetRootNode: composed not yet implemented")
+		n.Logger().Warn("Node.GetRootNode: composed not yet implemented")
 	}
 	if n.parent == nil {
 		return n.self
@@ -602,11 +602,14 @@ func (n *node) notify(event ChangeEvent) {
 	}
 }
 
-func (n *node) Logger() *slog.Logger {
+func (n *node) Logger() (res *slog.Logger) {
 	if docLogger, ok := n.document.(log.LogSource); ok {
-		return docLogger.Logger()
+		res = docLogger.Logger()
 	}
-	return nil
+	if res == nil {
+		res = log.Default()
+	}
+	return res
 }
 
 /* -------- observerCloser -------- */

--- a/dom/parent_node.go
+++ b/dom/parent_node.go
@@ -3,7 +3,6 @@ package dom
 import (
 	"slices"
 
-	"github.com/gost-dom/browser/internal/log"
 	"github.com/gost-dom/css"
 )
 
@@ -110,7 +109,7 @@ func (f parentNode) ChildElementCount() int {
 }
 
 func (n parentNode) QuerySelector(pattern string) (Element, error) {
-	log.Debug(n.node.Logger(), "parentNode.QuerySelector", "pattern", pattern)
+	n.node.Logger().Debug("parentNode.QuerySelector", "pattern", pattern)
 	nodes, err := n.QuerySelectorAll(pattern)
 	if err != nil {
 		return nil, err

--- a/html/history.go
+++ b/html/history.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/gost-dom/browser/dom/event"
 	htmlinterfaces "github.com/gost-dom/browser/internal/interfaces/html-interfaces"
-	"github.com/gost-dom/browser/internal/log"
 )
 
 const HistoryEventPopState = "popstate"
@@ -126,7 +125,7 @@ func (h History) currentIdx() int {
 //
 // [replaceState on the History API]: https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState
 func (h *History) PushState(state HistoryState, href string) error {
-	log.Info(h.logger(), "History.PushState", "href", href)
+	h.logger().Info("History.PushState", "href", href)
 	newHref := h.window.setBaseLocation(href)
 	h.pushHistoryEntry(historyEntry{state: state, href: newHref, remote: false})
 	return nil

--- a/html/html_element.go
+++ b/html/html_element.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gost-dom/browser/dom"
 	. "github.com/gost-dom/browser/internal/dom"
+	"github.com/gost-dom/browser/internal/log"
 	"github.com/gost-dom/browser/internal/uievents"
 )
 
@@ -108,9 +109,12 @@ func (e *htmlElement) SetAutofocus(val bool) {
 	}
 }
 
-func (e *htmlElement) logger() *slog.Logger {
+func (e *htmlElement) logger() (res *slog.Logger) {
 	if win := e.window(); win != nil {
-		return win.Logger()
+		res = win.Logger()
 	}
-	return nil
+	if res == nil {
+		res = log.Default()
+	}
+	return
 }

--- a/html/html_script_element.go
+++ b/html/html_script_element.go
@@ -20,7 +20,7 @@ func NewHTMLScriptElement(ownerDocument HTMLDocument) HTMLElement {
 }
 
 func (e *htmlScriptElement) Connected() {
-	log.Debug(e.logger(), "<script> connected", "element", e)
+	e.logger().Debug("<script> connected", "element", e)
 	var (
 		err         error
 		deferScript bool
@@ -30,20 +30,20 @@ func (e *htmlScriptElement) Connected() {
 	window, _ := e.htmlDocument.getWindow().(*window)
 	if !hasSrc {
 		if e.script, err = window.scriptContext.Compile(e.TextContent()); err != nil {
-			log.Error(e.Logger(), "HTMLScriptElement: compile error", "src", src, "err", err)
+			e.logger().Error("HTMLScriptElement: compile error", "src", src, "err", err)
 			return
 		}
 	} else {
 		src = window.resolveHref(src).Href()
 		if scriptType == "module" {
 			if e.script, err = window.scriptContext.DownloadModule(src); err != nil {
-				log.Error(e.Logger(), "HTMLScriptElement: download script error", "src", src, "err", err)
+				e.logger().Error("HTMLScriptElement: download script error", "src", src, "err", err)
 				return
 			}
 			deferScript = true
 		} else {
 			if e.script, err = window.scriptContext.DownloadScript(src); err != nil {
-				log.Error(e.Logger(), "HTMLScriptElement: download script error", "src", src, "err", err)
+				e.logger().Error("HTMLScriptElement: download script error", "src", src, "err", err)
 				return
 			}
 			_, deferScript = e.GetAttribute("defer")
@@ -58,10 +58,9 @@ func (e *htmlScriptElement) Connected() {
 
 func (e *htmlScriptElement) run() {
 	if err := e.script.Run(); err != nil {
-		// TODO: Dispatch "error" event
-		log.Error(e.Logger(), "Script error", "src", e.src, log.ErrAttr(err))
+		e.logger().Error("Script error", "src", e.src, log.ErrAttr(err))
 	}
-	log.Debug(e.Logger(), "Script execution completed", "src", e.src, "hasSource", e.src != "")
+	e.logger().Debug("Script execution completed", "src", e.src, "hasSource", e.src != "")
 }
 
 func (e *htmlScriptElement) AppendChild(n dom.Node) (dom.Node, error) {

--- a/html/window.go
+++ b/html/window.go
@@ -293,13 +293,13 @@ func (w *window) parseReader(reader io.Reader) error {
 }
 
 func (w *window) Navigate(href string) (err error) {
-	log.Info(w.Logger(), "Window.navigate:", "href", href)
+	w.Logger().Info("Window.navigate:", "href", href)
 	if w.baseLocation != "about:blank" {
 		href = w.resolveHref(href).String()
 	}
 	defer func() {
 		if err != nil {
-			log.Warn(w.logger, "Window.navigate: Error response", log.ErrAttr(err))
+			w.Logger().Warn("Window.navigate: Error response", log.ErrAttr(err))
 		}
 	}()
 	w.History().pushLoad(href)
@@ -316,7 +316,7 @@ func (w *window) Navigate(href string) (err error) {
 // reload is used internally to load a page into the browser, but without
 // affecting the history
 func (w *window) reload(href string) error {
-	log.Debug(w.Logger(), "Window.reload:", "href", href)
+	w.Logger().Debug("Window.reload:", "href", href)
 	w.initScriptEngine()
 	w.baseLocation = href
 	if href == "about:blank" {
@@ -405,7 +405,12 @@ func (w *window) resolveHref(href string) *url.URL {
 	return r
 }
 
-func (w *window) Logger() log.Logger { return w.logger }
+func (w *window) Logger() log.Logger {
+	if w.logger != nil {
+		return w.logger
+	}
+	return log.Default()
+}
 
 type WindowOptions struct {
 	ScriptHost

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gost-dom/browser/html"
 	"github.com/gost-dom/browser/internal/dom"
-	"github.com/gost-dom/browser/internal/log"
 	"github.com/gost-dom/browser/internal/promise"
 	"github.com/gost-dom/browser/internal/streams"
 	"github.com/gost-dom/browser/url"
@@ -76,7 +75,7 @@ func (r *Request) do(ctx context.Context) (*http.Response, error) {
 		method = "GET"
 	}
 	url := r.URL()
-	log.Info(r.bc.Logger(), "gost-dom/fetch: Request.do", "method", method, "url", url)
+	r.bc.Logger().Info("gost-dom/fetch: Request.do", "method", method, "url", url)
 	req, err := http.NewRequestWithContext(ctx, method, url, r.body)
 	if err != nil {
 		return nil, err

--- a/internal/html/xml_http_request.go
+++ b/internal/html/xml_http_request.go
@@ -89,7 +89,7 @@ func NewXmlHttpRequest(ctx html.BrowsingContext, clock *clock.Clock) XmlHttpRequ
 		async:       true,
 	}
 	event.SetEventTargetSelf(result)
-	log.Info(result.logSource.Logger(), "NewXmlHttpRequest", "location", location)
+	result.logSource.Logger().Info("NewXmlHttpRequest", "location", location)
 	return result
 }
 func (r *xmlHttpRequest) logger() log.Logger {
@@ -105,7 +105,7 @@ func (req *xmlHttpRequest) Open(
 	// binding layer? Or different methods?
 	url string,
 	options ...RequestOption) {
-	log.Info(req.logger(), "XmlHttpRequest.Open", "method", method, "url", url)
+	req.logger().Info("XmlHttpRequest.Open", "method", method, "url", url)
 
 	req.method = method
 	req.url = url
@@ -120,7 +120,7 @@ func (req *xmlHttpRequest) send(body io.Reader) error {
 	if u := url.ParseURLBase(req.url, req.location); u != nil {
 		reqUrl = u.Href()
 	}
-	log.Info(req.logger(), "XmlHttpRequest.send", "url", reqUrl)
+	req.logger().Info("XmlHttpRequest.send", "url", reqUrl)
 	httpRequest, err := http.NewRequest(req.method, reqUrl, body)
 	if err != nil {
 		return err
@@ -135,7 +135,7 @@ func (req *xmlHttpRequest) send(body io.Reader) error {
 	b := new(bytes.Buffer) // TODO, branch out depending on content-type
 	_, err = b.ReadFrom(res.Body)
 	req.response = b.Bytes()
-	log.Debug(req.logger(), "Response received", "Status", res.StatusCode)
+	req.logger().Debug("Response received", "Status", res.StatusCode)
 	req.DispatchEvent(&event.Event{Type: XHREventLoad})
 	return err
 }
@@ -156,8 +156,7 @@ func (req *xmlHttpRequest) Send(body io.Reader) error {
 }
 
 func (req *xmlHttpRequest) SendBody(body io.Reader) error {
-	log.Warn(
-		req.logger(),
+	req.logger().Warn(
 		"Using deprecated method XMLHttpRequest.SendBody(io.Reader). Use Send(io.Reader) instead",
 	)
 	return req.Send(body)

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -36,30 +36,6 @@ func Default() *slog.Logger {
 	return defaultLogger
 }
 
-func logger(source Logger) *slog.Logger {
-	if source != nil {
-		return source
-	} else {
-		return Default()
-	}
-}
-
-func Info(source Logger, msg string, args ...any) {
-	logger(source).Info(msg, args...)
-}
-
-func Warn(source Logger, msg string, args ...any) {
-	logger(source).Warn(msg, args...)
-}
-
-func Debug(source Logger, msg string, args ...any) {
-	logger(source).Debug(msg, args...)
-}
-
-func Error(source Logger, msg string, args ...any) {
-	logger(source).Error(msg, args...)
-}
-
 // ErrAttr creates a log record attribute representing an error.
 //
 // If the error originates from V8, the relevant JavaScript location and stack

--- a/scripting/v8host/script_context.go
+++ b/scripting/v8host/script_context.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gost-dom/browser/internal/constants"
 	"github.com/gost-dom/browser/internal/entity"
 	"github.com/gost-dom/browser/internal/gosthttp"
-	"github.com/gost-dom/browser/internal/log"
 	"github.com/gost-dom/browser/scripting/internal/js"
 	"github.com/gost-dom/browser/url"
 	"github.com/gost-dom/v8go"
@@ -131,7 +130,6 @@ func (ctx *V8ScriptContext) Close() {
 	ctx.disposed = true
 
 	ctx.host.inspector.ContextDestroyed(ctx.v8ctx)
-	log.Debug(ctx.host.logger, "ScriptContext: Dispose")
 	for _, dispose := range ctx.disposers {
 		dispose.Dispose()
 	}

--- a/scripting/v8host/script_host.go
+++ b/scripting/v8host/script_host.go
@@ -72,14 +72,14 @@ func (f consoleAPIMessageFunc) ConsoleAPIMessage(message v8go.ConsoleAPIMessage)
 func (host *V8ScriptHost) consoleAPIMessage(message v8go.ConsoleAPIMessage) {
 	switch message.ErrorLevel {
 	case v8go.ErrorLevelDebug:
-		log.Debug(host.logger, message.Message)
+		host.Logger().Debug(message.Message)
 	case v8go.ErrorLevelInfo:
 	case v8go.ErrorLevelLog:
-		log.Info(host.logger, message.Message)
+		host.Logger().Info(message.Message)
 	case v8go.ErrorLevelWarning:
-		log.Warn(host.logger, message.Message)
+		host.Logger().Warn(message.Message)
 	case v8go.ErrorLevelError:
-		log.Error(host.logger, message.Message)
+		host.Logger().Error(message.Message)
 	}
 }
 
@@ -140,8 +140,7 @@ func (host *V8ScriptHost) Close() {
 	undisposedCount := len(undisposedContexts)
 
 	if undisposedCount > 0 {
-		log.Warn(
-			host.logger,
+		host.Logger().Warn(
 			"Closing script host with undisposed contexts",
 			"count",
 			undisposedCount,


### PR DESCRIPTION
Instead of having a level of indirection for logging, accepting nil values, instead have functions that always return valid loggers, defaulting to a null-logger if nothing is specified.

This makes the code clearer, but the other also has an unfortunate side effect of messing up the call stack.