### PR TITLE
refactor: return implementation type from interface

### DIFF
--- a/html/html_anchor_element.go
+++ b/html/html_anchor_element.go
@@ -53,7 +53,7 @@ func (e *htmlAnchorElement) getUrl(f func(*url.URL) string) string {
 }
 
 func (e *htmlAnchorElement) SetHref(val string) {
-	window := e.getHTMLDocument().getWindow()
+	window := e.getHTMLDocument().window()
 	newUrl := window.resolveHref(val)
 	e.URL = newUrl
 	e.updateDataAttribute()

--- a/html/html_document.go
+++ b/html/html_document.go
@@ -9,13 +9,13 @@ import (
 type HTMLDocument interface {
 	dom.Document
 	// unexported
-	getWindow() Window
+	window() *window
 	setActiveElement(e dom.Element)
 }
 
 type htmlDocument struct {
 	dom.Document
-	window Window
+	win Window
 }
 
 func mustAppendChild(p, c dom.Node) dom.Node {
@@ -85,7 +85,12 @@ func (d *htmlDocument) CreateElement(name string) dom.Element {
 	return NewHTMLElement(name, d)
 }
 
-func (d *htmlDocument) getWindow() Window { return d.window }
+func (d *htmlDocument) window() *window {
+	if d.win == nil {
+		return nil
+	}
+	return d.win.window()
+}
 
 type SetActiveElementer interface {
 	SetActiveElement(e dom.Element)

--- a/html/html_element.go
+++ b/html/html_element.go
@@ -58,7 +58,7 @@ func (e *htmlElement) SetSelf(self dom.Node) {
 
 func (e *htmlElement) getHTMLDocument() HTMLDocument { return e.htmlDocument }
 
-func (e *htmlElement) window() Window { return e.getHTMLDocument().getWindow() }
+func (e *htmlElement) window() Window { return e.getHTMLDocument().window() }
 
 func (e *htmlElement) TagName() string {
 	return strings.ToUpper(e.Element.TagName())

--- a/html/html_form_element.go
+++ b/html/html_form_element.go
@@ -128,7 +128,7 @@ func (e *htmlFormElement) submitFormData(formData *FormData) error {
 	if err != nil {
 		return err
 	}
-	return e.htmlDocument.getWindow().fetchRequest(req)
+	return e.htmlDocument.window().fetchRequest(req)
 }
 
 func (e *htmlFormElement) RequestSubmit(submitter dom.Element) error {

--- a/html/html_script_element.go
+++ b/html/html_script_element.go
@@ -24,7 +24,7 @@ func (e *htmlScriptElement) Connected() {
 		err         error
 		deferScript bool
 	)
-	window, _ := e.htmlDocument.getWindow().(*window)
+	window := e.htmlDocument.window()
 	e.script, deferScript, err = e.compile()
 	if err != nil {
 		e.logger().Error("HTMLScriptElement: script error", log.ErrAttr(err))
@@ -39,7 +39,7 @@ func (e *htmlScriptElement) Connected() {
 
 func (e *htmlScriptElement) compile() (script Script, deferred bool, err error) {
 	src, hasSrc := e.GetAttribute("src")
-	window, _ := e.htmlDocument.getWindow().(*window)
+	window := e.htmlDocument.window()
 	if !hasSrc {
 		script, err = window.scriptContext.Compile(e.TextContent())
 		if err != nil {

--- a/html/html_template_element.go
+++ b/html/html_template_element.go
@@ -36,7 +36,7 @@ func (e *htmlTemplateElement) RenderChildren(builder *strings.Builder) {
 
 func (e *htmlTemplateElement) SetInnerHTML(html string) error {
 	doc := e.htmlDocument
-	fragment, err := doc.getWindow().ParseFragment(doc, strings.NewReader(html))
+	fragment, err := doc.window().ParseFragment(doc, strings.NewReader(html))
 	if err == nil {
 		e.content = fragment
 	}

--- a/html/window.go
+++ b/html/window.go
@@ -149,6 +149,7 @@ type Window interface {
 
 	fetchRequest(req *http.Request) error
 	resolveHref(string) *url.URL
+	window() *window
 }
 
 type window struct {
@@ -411,6 +412,8 @@ func (w *window) Logger() log.Logger {
 	}
 	return log.Default()
 }
+
+func (w *window) window() *window { return w }
 
 type WindowOptions struct {
 	ScriptHost


### PR DESCRIPTION
The unexported getWindow() could type-safely return a *window, avoiding a type cast later.