### PR TITLE
fix: Fix potential race condition when closing browser

### DIFF
--- a/html/window.go
+++ b/html/window.go
@@ -267,6 +267,9 @@ func (w *window) ParseFragment(
 //
 // If this function returns without an error, the DOM will have been parsed and
 // the DOMContentLoaded event has been dispached on the [dom.Document]
+//
+// Experimental: This function will likely be removed in favour of other ways of
+// creating an initialized window
 func NewWindowReader(reader io.Reader, windowOptions ...WindowOption) (Window, error) {
 	window := newWindow(windowOptions...)
 	err := window.parseReader(reader)


### PR DESCRIPTION
When a browser is initialized with a context, `browser.Close()` is implicitly called from a goroutine when the context cancels. If the browser is explicitly closed be a call to `browser.Close()`, this could lead to a race condition.

```
func TestSomething(t *testing.T) {
   // When the test exits, the context cancels, calling `Close()` in a
   // new goroutine
   b := browser.New(browser.WithContext(t.Context()))
   // When the test exits, the test framework calls `Close()` in the
   // test goroutine (AFAIK)
   t.Cleanup(b.Close)

   // The two calls could race each other.
   // New windows are also protected, although it is an unlikely usecase
   // to create new windows after calling close, the race condition
   // could still lead to messed up reasources
}
```