### PR TITLE
fix: Element.classlist trims whitespace

### DIFF
--- a/dom/class_list.go
+++ b/dom/class_list.go
@@ -108,11 +108,11 @@ func (l DOMTokenList) Toggle(token string) bool {
 }
 
 func (l DOMTokenList) getTokens() []string {
-	tokens := l.Value()
-	if strings.TrimSpace(tokens) == "" {
+	tokens := strings.TrimSpace(l.Value())
+	if tokens == "" {
 		return []string{}
 	}
-	return strings.Split(tokens, " ")
+	return strings.Fields(tokens)
 }
 
 func (l DOMTokenList) setTokens(tokens []string) {

--- a/dom/class_list_test.go
+++ b/dom/class_list_test.go
@@ -45,6 +45,13 @@ func TestClassList(t *testing.T) {
 	}
 	{
 		pair := initClassListPair(doc)
+		pair.element.SetAttribute("class", "c1 c2 ")
+		expect(pair.classList.Add("c3")).To(Succeed())
+		expect(pair.element).To(
+			HaveAttribute("class", "c1 c2 c3"), "Extra space in class is ignored")
+	}
+	{
+		pair := initClassListPair(doc)
 		pair.element.SetAttribute("class", "c1 c2")
 		expect(pair.classList.Add("c1", "c3")).To(Succeed())
 		expect(pair.element).To(


### PR DESCRIPTION
If an element has untrimmed space in the class attribute, that was kept when using classList to modify it. That is fixed now