### PR TITLE
fix: remove unused runtime/cgo import that broke non-CGo builds

### DIFF
--- a/scripting/internal/url/url.go
+++ b/scripting/internal/url/url.go
@@ -2,7 +2,6 @@ package url
 
 import (
 	"fmt"
-	"runtime/cgo"
 
 	"github.com/gost-dom/browser/html"
 	"github.com/gost-dom/browser/internal/constants"
@@ -17,10 +16,6 @@ type URL[T any] struct {
 func NewURL[T any](host js.ScriptEngine[T]) URL[T] {
 	return URL[T]{}
 }
-
-type handleDisposable cgo.Handle
-
-func (h handleDisposable) Dispose() { cgo.Handle(h).Delete() }
 
 func CreateURL[T any](
 	cbCtx js.CallbackContext[T],


### PR DESCRIPTION
The handleDisposable type in scripting/internal/url/url.go was unused dead code that imported runtime/cgo, preventing sobekengine (and any package depending on scripting/internal/url) from compiling or testing without a C compiler.