### PR TITLE
fix(fetch): forward request headers to the outgoing HTTP request

### DIFF
--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -61,6 +61,8 @@ type Request struct {
 
 func (r *Request) URL() string { return url.ParseURLBase(r.url, r.bc.LocationHREF()).Href() }
 
+// createHttpReq builds the outgoing [http.Request] for this fetch Request,
+// defaulting the method to GET and forwarding the request headers.
 func (r *Request) createHttpReq(ctx context.Context) (*http.Request, error) {
 	method := r.method
 	if method == "" {
@@ -68,7 +70,18 @@ func (r *Request) createHttpReq(ctx context.Context) (*http.Request, error) {
 	}
 	url := r.URL()
 	r.bc.Logger().Info("gost-dom/fetch: Request.do", "method", method, "url", url)
-	return http.NewRequestWithContext(ctx, method, url, r.body)
+	req, err := http.NewRequestWithContext(ctx, method, url, r.body)
+	if err != nil {
+		return nil, err
+	}
+	// Forward the request headers to the outgoing HTTP request. Without this,
+	// headers set via fetch's RequestInit (e.g. Content-Type, Authorization, or
+	// custom API headers) were silently dropped, causing servers that require
+	// them to reject the request.
+	for name, value := range r.Headers.All() {
+		req.Header.Add(string(name), string(value))
+	}
+	return req, nil
 }
 
 func (r *Request) do(req *http.Request) (*http.Response, error) {

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -61,8 +61,6 @@ type Request struct {
 
 func (r *Request) URL() string { return url.ParseURLBase(r.url, r.bc.LocationHREF()).Href() }
 
-// createHttpReq builds the outgoing [http.Request] for this fetch Request,
-// defaulting the method to GET and forwarding the request headers.
 func (r *Request) createHttpReq(ctx context.Context) (*http.Request, error) {
 	method := r.method
 	if method == "" {
@@ -74,10 +72,6 @@ func (r *Request) createHttpReq(ctx context.Context) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Forward the request headers to the outgoing HTTP request. Without this,
-	// headers set via fetch's RequestInit (e.g. Content-Type, Authorization, or
-	// custom API headers) were silently dropped, causing servers that require
-	// them to reject the request.
 	for name, value := range r.Headers.All() {
 		req.Header.Add(string(name), string(value))
 	}

--- a/internal/fetch/headers.go
+++ b/internal/fetch/headers.go
@@ -37,12 +37,14 @@ func compareHeaders(a, b Header) int {
 }
 
 func (h *Headers) Append(name, val types.ByteString) {
-	// In order to have correct iteration behaviour, it's imperative that the
-	// list is kept sorted.
+	// Forbidden header names are matched case-insensitively, so normalise the
+	// name before both the check and insertion. Keeping the list sorted is
+	// imperative for correct iteration behaviour.
+	name = name.ToLower()
 	if slices.Index(h.invalidHeaders, name) != -1 {
 		return
 	}
-	h.headers = insertSorted(h.headers, Header{key: name.ToLower(), val: val}, compareHeaders)
+	h.headers = insertSorted(h.headers, Header{key: name, val: val}, compareHeaders)
 }
 
 func (h *Headers) Delete(name types.ByteString) {

--- a/internal/fetch/request_headers_test.go
+++ b/internal/fetch/request_headers_test.go
@@ -1,0 +1,39 @@
+package fetch_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gost-dom/browser/internal/fetch"
+	"github.com/gost-dom/browser/internal/testing/gosttest"
+	"github.com/gost-dom/browser/internal/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFetchForwardsHeaders verifies that headers set on a fetch Request are
+// forwarded onto the outgoing HTTP request.
+func TestFetchForwardsHeaders(t *testing.T) {
+	recorder := gosttest.NewHTTPRequestRecorder(t,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }),
+	)
+	bc, cancel := gosttest.NewBrowsingContextFromT(t, recorder, gosttest.WithTimeoutMS(100))
+	defer cancel()
+
+	f := fetch.New(bc)
+	res, err := f.Fetch(f.NewRequest("url",
+		fetch.WithMethod("POST"),
+		fetch.WithHeaders([][2]types.ByteString{
+			{"Content-Type", "application/json+protobuf"},
+			{"X-Goog-Api-Key", "secret-key"},
+		}),
+	))
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, 200, res.Status)
+	req := recorder.Requests[0]
+	assert.Equal(t, "application/json+protobuf", req.Header.Get("Content-Type"),
+		"Content-Type header forwarded to the outgoing request")
+	assert.Equal(t, "secret-key", req.Header.Get("X-Goog-Api-Key"),
+		"custom header forwarded to the outgoing request")
+}

--- a/internal/fetch/request_headers_test.go
+++ b/internal/fetch/request_headers_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // TestFetchForwardsHeaders verifies that headers set on a fetch Request are
-// forwarded onto the outgoing HTTP request.
+// forwarded onto the request sent by the http.Client to the round tripper.
 func TestFetchForwardsHeaders(t *testing.T) {
 	recorder := gosttest.NewHTTPRequestRecorder(t,
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }),
@@ -23,17 +23,45 @@ func TestFetchForwardsHeaders(t *testing.T) {
 	res, err := f.Fetch(f.NewRequest("url",
 		fetch.WithMethod("POST"),
 		fetch.WithHeaders([][2]types.ByteString{
-			{"Content-Type", "application/json+protobuf"},
-			{"X-Goog-Api-Key", "secret-key"},
+			{"Content-Type", "application/json"},
+			{"X-Example-Header", "example-value"},
 		}),
 	))
 	if !assert.NoError(t, err) {
 		return
 	}
 	assert.Equal(t, 200, res.Status)
-	req := recorder.Requests[0]
-	assert.Equal(t, "application/json+protobuf", req.Header.Get("Content-Type"),
+	req := recorder.Single()
+	assert.Equal(t, "application/json", req.Header.Get("Content-Type"),
 		"Content-Type header forwarded to the outgoing request")
-	assert.Equal(t, "secret-key", req.Header.Get("X-Goog-Api-Key"),
+	assert.Equal(t, "example-value", req.Header.Get("X-Example-Header"),
 		"custom header forwarded to the outgoing request")
+}
+
+// TestFetchDoesNotForwardCookieHeaders verifies that cookie-related headers are
+// not forwarded onto the outgoing request. They are forbidden request headers;
+// cookies on real requests are managed by the http.Client's cookie jar, not by
+// copying header values.
+func TestFetchDoesNotForwardCookieHeaders(t *testing.T) {
+	recorder := gosttest.NewHTTPRequestRecorder(t,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }),
+	)
+	bc, cancel := gosttest.NewBrowsingContextFromT(t, recorder, gosttest.WithTimeoutMS(100))
+	defer cancel()
+
+	f := fetch.New(bc)
+	_, err := f.Fetch(f.NewRequest("url",
+		fetch.WithHeaders([][2]types.ByteString{
+			{"Cookie", "session=example"},
+			{"Set-Cookie", "session=example"},
+		}),
+	))
+	if !assert.NoError(t, err) {
+		return
+	}
+	req := recorder.Single()
+	assert.Empty(t, req.Header.Values("Cookie"),
+		"Cookie is a forbidden request header and must not be forwarded")
+	assert.Empty(t, req.Header.Values("Set-Cookie"),
+		"Set-Cookie is a forbidden request header and must not be forwarded")
 }


### PR DESCRIPTION
`Request.createHttpReq` builds the `*http.Request` but never copies the request's `Headers` onto it. As a result, any header set via fetch's `RequestInit` (`Content-Type`, `Authorization`, custom API headers, …) is silently dropped, and servers that require those headers reject the request.

This forwards the request headers to the outgoing request.

**Testing:** added `TestFetchForwardsHeaders`; `go test ./internal/fetch/` passes.

---
*AI disclosure:* This change was developed with the help of an AI coding assistant. I've reviewed and tested it myself; it follows the existing conventions and the full test suite (main module, `v8engine`, `sobekengine`) passes locally.
