### PR TITLE
feat(v8engine): set @@toStringTag on interface prototypes

### DIFF
--- a/scripting/internal/scripttests/suites.go
+++ b/scripting/internal/scripttests/suites.go
@@ -54,6 +54,7 @@ func RunSuites(t *testing.T, e html.ScriptEngine) {
 	t.Run("NodeList", runSuite(NewNodeListSuite(e)))
 	t.Run("AbortController", runSuite(NewAbortControllerSuite(e)))
 	t.Run("Console", func(t *testing.T) { testConsole(t, e) })
+	t.Run("ToStringTag", func(t *testing.T) { testToStringTag(t, e) })
 	t.Run("Fetch", func(t *testing.T) { testFetch(t, e) })
 	t.Run("Streams", func(t *testing.T) { testStreams(t, e) })
 	t.Run("CharacterData", func(t *testing.T) { testCharacterData(t, e) })

--- a/scripting/internal/scripttests/tostringtag_suite.go
+++ b/scripting/internal/scripttests/tostringtag_suite.go
@@ -1,18 +1,18 @@
-package v8engine_test
+package scripttests
 
 import (
 	"testing"
 
+	"github.com/gost-dom/browser/html"
 	"github.com/gost-dom/browser/internal/testing/browsertest"
-	"github.com/gost-dom/browser/scripting/v8engine"
 	"github.com/stretchr/testify/assert"
 )
 
-// TestInterfaceToStringTag verifies that interface prototypes carry the Web-IDL
+// testToStringTag verifies that interface prototypes carry the Web IDL
 // @@toStringTag, so Object.prototype.toString.call(obj) yields "[object <Name>]"
 // rather than the generic "[object Object]".
-func TestInterfaceToStringTag(t *testing.T) {
-	win := browsertest.InitWindow(t, v8engine.DefaultEngine())
+func testToStringTag(t *testing.T, e html.ScriptEngine) {
+	win := browsertest.InitWindow(t, e)
 	eq := func(name, script string, want any) {
 		t.Helper()
 		assert.Equal(t, want, win.MustEval(script), name)

--- a/scripting/sobekengine/class.go
+++ b/scripting/sobekengine/class.go
@@ -1,6 +1,8 @@
 package sobekengine
 
 import (
+	"fmt"
+
 	"github.com/gost-dom/browser/scripting/internal/js"
 	"github.com/grafana/sobek"
 )
@@ -81,6 +83,33 @@ func (c class) CreateIteratorMethod(cb js.CallbackFunc[jsTypeParam]) {
 		sobek.SymIterator,
 		wrapJSCallback(c.ctx, cb.WithLog(c.name, "Symbol.Iterator")),
 	)
+}
+
+// setToStringTag installs the Web IDL class string as obj's @@toStringTag, so
+// Object.prototype.toString.call(obj) yields "[object <Name>]" instead of the
+// generic "[object Object]". Per Web IDL the property is { writable: false,
+// enumerable: false, configurable: true }.
+//
+// For interface prototypes obj is the prototype, which instances inherit from.
+// For the global object the tag must be set on the global object itself, as
+// Sobek gives it an own @@toStringTag of "global" that would otherwise shadow
+// the inherited one.
+//
+// https://webidl.spec.whatwg.org/#dfn-class-string
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag
+func (c *class) setToStringTag(obj *sobek.Object) {
+	if c.name == "" {
+		return
+	}
+	if err := obj.DefineDataPropertySymbol(
+		sobek.SymToStringTag,
+		c.ctx.vm.ToValue(c.name),
+		sobek.FLAG_FALSE, // writable
+		sobek.FLAG_TRUE,  // configurable
+		sobek.FLAG_FALSE, // enumerable
+	); err != nil {
+		panic(fmt.Sprintf("gost-dom/sobek: set @@toStringTag for %s: %v", c.name, err))
+	}
 }
 
 func (c *class) NewInstance(native any) (js.Object[jsTypeParam], error) {

--- a/scripting/sobekengine/script_context.go
+++ b/scripting/sobekengine/script_context.go
@@ -194,6 +194,7 @@ func (c *scriptContext) CreateClass(
 	cls.prototype = constructor.Get("prototype").(*sobek.Object)
 	c.vm.Set(name, constructor)
 	c.classes[name] = cls
+	cls.setToStringTag(cls.prototype)
 
 	if extends != nil {
 		if superclass, ok := extends.(*class); ok {
@@ -221,6 +222,9 @@ func (c *scriptContext) ConfigureGlobalScope(
 	)
 	cls.prototype = constructor.Get("prototype").(*sobek.Object)
 	c.vm.Set(name, constructor)
+	// The global object carries its own @@toStringTag ("global" in Sobek), which
+	// shadows the prototype, so the tag is set on the global object directly.
+	cls.setToStringTag(c.globalThis())
 
 	if extends != nil {
 		if superclass, ok := extends.(*class); ok {

--- a/scripting/v8engine/class.go
+++ b/scripting/v8engine/class.go
@@ -64,6 +64,11 @@ func newV8Class(
 	// yields "[object Navigator]" rather than "[object Object]". Without this,
 	// every host object incorrectly stringifies to "[object Object]". The
 	// most-derived class on the prototype chain wins, which matches browsers.
+	// Per Web IDL the property is { writable: false, enumerable: false,
+	// configurable: true }; ReadOnly|DontEnum covers the first two.
+	//
+	// https://webidl.spec.whatwg.org/#dfn-class-string
+	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag
 	if name != "" {
 		if err := result.proto.SetSymbol(
 			v8go.SymbolToStringTag(host.iso), name, v8go.ReadOnly|v8go.DontEnum,

--- a/scripting/v8engine/class.go
+++ b/scripting/v8engine/class.go
@@ -36,6 +36,9 @@ func jsClassToV8Class(cls js.Class[jsTypeParam]) *v8Class {
 	return res
 }
 
+// newV8Class creates a v8Class for the named interface, wiring up its
+// constructor, prototype and instance templates (including inherited instance
+// attributes) and the Web-IDL @@toStringTag.
 func newV8Class(
 	host *V8ScriptHost,
 	name string,
@@ -56,6 +59,18 @@ func newV8Class(
 		parent: parent,
 	}
 	result.inst.SetInternalFieldCount(1)
+	// Per Web IDL, every interface prototype carries an @@toStringTag property
+	// equal to the interface name, so Object.prototype.toString.call(navigator)
+	// yields "[object Navigator]" rather than "[object Object]". Without this,
+	// every host object incorrectly stringifies to "[object Object]". The
+	// most-derived class on the prototype chain wins, which matches browsers.
+	if name != "" {
+		if err := result.proto.SetSymbol(
+			v8go.SymbolToStringTag(host.iso), name, v8go.ReadOnly|v8go.DontEnum,
+		); err != nil {
+			panic(fmt.Sprintf("gost-dom/v8engine: set @@toStringTag for %s: %v", name, err))
+		}
+	}
 	for parent != nil {
 		// Set accessor properties of inherited classes on the instance
 		// template.

--- a/scripting/v8engine/tostringtag_test.go
+++ b/scripting/v8engine/tostringtag_test.go
@@ -1,0 +1,27 @@
+package v8engine_test
+
+import (
+	"testing"
+
+	"github.com/gost-dom/browser/internal/testing/browsertest"
+	"github.com/gost-dom/browser/scripting/v8engine"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestInterfaceToStringTag verifies that interface prototypes carry the Web-IDL
+// @@toStringTag, so Object.prototype.toString.call(obj) yields "[object <Name>]"
+// rather than the generic "[object Object]".
+func TestInterfaceToStringTag(t *testing.T) {
+	win := browsertest.InitWindow(t, v8engine.DefaultEngine())
+	eq := func(name, script string, want any) {
+		t.Helper()
+		assert.Equal(t, want, win.MustEval(script), name)
+	}
+
+	eq("window", `Object.prototype.toString.call(window)`, "[object Window]")
+	eq("document", `Object.prototype.toString.call(document)`, "[object HTMLDocument]")
+	eq("div element", `Object.prototype.toString.call(document.createElement("div"))`, "[object HTMLDivElement]")
+	eq("Headers", `Object.prototype.toString.call(new Headers())`, "[object Headers]")
+	// The most-derived class on the prototype chain provides the tag.
+	eq("anchor element", `Object.prototype.toString.call(document.createElement("a"))`, "[object HTMLAnchorElement]")
+}


### PR DESCRIPTION
Per Web IDL, every interface prototype carries a `Symbol.toStringTag` equal to the interface name. gost-dom didn't set it, so `Object.prototype.toString.call(navigator)` (and every other host object) returned the generic `"[object Object]"` instead of `"[object Navigator]"`, `"[object HTMLDivElement]"`, etc.

Set generically in `newV8Class` (the most-derived class on the prototype chain provides the tag, matching browsers).

**Testing:** added `TestInterfaceToStringTag` (window, document, div, anchor, Headers).

---
*AI disclosure:* This change was developed with the help of an AI coding assistant. I've reviewed and tested it myself; it follows the existing conventions and the full test suite (main module, `v8engine`, `sobekengine`) passes locally.
