### PR TITLE
feat(html): make the navigator profile configurable

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -56,6 +56,14 @@ func WithScriptEngine(engine html.ScriptEngine) BrowserOption {
 	return func(b *browserConfig) { b.engine = engine }
 }
 
+// WithNavigator configures the values reported by the window's navigator (user
+// agent, platform, languages, hardware concurrency, ...). This lets client code
+// dictate the browser identity rather than relying on the default profile.
+// Fields left zero fall back to [html.DefaultNavigatorProfile].
+func WithNavigator(profile html.NavigatorProfile) BrowserOption {
+	return WithComponentType(profile)
+}
+
 // WithContext passes a [context.Context] than can trigger cancellation, e.g.:
 //
 //   - Close any open HTTP connections and disconnect from the server.

--- a/html/navigator.go
+++ b/html/navigator.go
@@ -2,6 +2,78 @@ package html
 
 import "github.com/gost-dom/browser/internal/entity"
 
+// NavigatorProfile describes the values reported by the window's navigator. It
+// lets client code dictate the browser identity when creating a browser, rather
+// than the core module hardcoding a single profile.
+//
+// Configure it with the browser package's WithNavigator option. Fields left as
+// their zero value fall back to the corresponding [DefaultNavigatorProfile]
+// value, so a partial profile only needs to set the fields it cares about.
+type NavigatorProfile struct {
+	UserAgent string
+	Platform  string
+	Vendor    string
+	// Language defaults to the first entry of Languages when left empty.
+	Language            string
+	Languages           []string
+	HardwareConcurrency int
+}
+
+// DefaultNavigatorProfile is the profile reported when none is configured. It
+// describes a current Chrome release, so applications under test observe a
+// realistic, modern browser. Override it with the browser package's
+// WithNavigator option.
+var DefaultNavigatorProfile = NavigatorProfile{
+	UserAgent:           "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+	Platform:            "Linux x86_64",
+	Vendor:              "Google Inc.",
+	Language:            "en-US",
+	Languages:           []string{"en-US", "en"},
+	HardwareConcurrency: 8,
+}
+
+// withDefaults returns the profile with every zero-valued field replaced by the
+// corresponding [DefaultNavigatorProfile] value, so a partial profile remains
+// usable. An empty Language defaults to the first configured language.
+func (p NavigatorProfile) withDefaults() NavigatorProfile {
+	d := DefaultNavigatorProfile
+	if p.UserAgent == "" {
+		p.UserAgent = d.UserAgent
+	}
+	if p.Platform == "" {
+		p.Platform = d.Platform
+	}
+	if p.Vendor == "" {
+		p.Vendor = d.Vendor
+	}
+	if len(p.Languages) == 0 {
+		p.Languages = d.Languages
+	}
+	if p.Language == "" {
+		if len(p.Languages) > 0 {
+			p.Language = p.Languages[0]
+		} else {
+			p.Language = d.Language
+		}
+	}
+	if p.HardwareConcurrency == 0 {
+		p.HardwareConcurrency = d.HardwareConcurrency
+	}
+	return p
+}
+
 type Navigator struct {
 	entity.Entity
+	profile NavigatorProfile
 }
+
+func (n *Navigator) UserAgent() string        { return n.profile.UserAgent }
+func (n *Navigator) Platform() string         { return n.profile.Platform }
+func (n *Navigator) Vendor() string           { return n.profile.Vendor }
+func (n *Navigator) Language() string         { return n.profile.Language }
+func (n *Navigator) Languages() []string      { return n.profile.Languages }
+func (n *Navigator) HardwareConcurrency() int { return n.profile.HardwareConcurrency }
+
+// Webdriver reports navigator.webdriver. gost-dom drives pages
+// programmatically, but reports false to mirror an ordinary browsing session.
+func (n *Navigator) Webdriver() bool { return false }

--- a/html/window.go
+++ b/html/window.go
@@ -221,6 +221,10 @@ func newWindow(windowOptions ...WindowOption) *window {
 	for _, init := range options.ComponentInits {
 		init(win)
 	}
+	// Resolve the navigator profile from the configured component (if any),
+	// falling back to the default for every unset field.
+	profile, _ := entity.ComponentType[NavigatorProfile](win)
+	win.navigator.profile = profile.withDefaults()
 	if baseLocation == "" {
 		baseLocation = "about:blank"
 	}

--- a/scripting/internal/html/initializer.go
+++ b/scripting/internal/html/initializer.go
@@ -22,6 +22,7 @@ func ConfigureScriptEngine[T any](e js.ScriptEngine[T]) {
 	// See also: https://developer.mozilla.org/en-US/docs/Web/API/HTMLDocument
 	js.CreateClass(e, "HTMLDocument", "Document", js.IllegalConstructor)
 	installHtmlElementTypes(e)
+	installNavigator(e)
 }
 
 // installHtmlElementTypes adds classes for all the HTML element types work which

--- a/scripting/internal/html/navigator.go
+++ b/scripting/internal/html/navigator.go
@@ -1,0 +1,89 @@
+package html
+
+import (
+	"github.com/gost-dom/browser/html"
+	js "github.com/gost-dom/browser/scripting/internal/js"
+)
+
+// installNavigator adds the data attributes of the Navigator interface. Each
+// value is read from the per-window [html.Navigator] instance, so the reported
+// profile can be configured per browser via the browser package's WithNavigator
+// option.
+func installNavigator[T any](e js.ScriptEngine[T]) {
+	nav, ok := e.Class("Navigator")
+	if !ok {
+		return
+	}
+	nav.CreateAttribute("userAgent", navigatorUserAgent, nil)
+	nav.CreateAttribute("platform", navigatorPlatform, nil)
+	nav.CreateAttribute("vendor", navigatorVendor, nil)
+	nav.CreateAttribute("language", navigatorLanguage, nil)
+	nav.CreateAttribute("languages", navigatorLanguages, nil)
+	nav.CreateAttribute("hardwareConcurrency", navigatorHardwareConcurrency, nil)
+	nav.CreateAttribute("webdriver", navigatorWebdriver, nil)
+}
+
+func navigatorInstance[T any](cbCtx js.CallbackContext[T]) (*html.Navigator, error) {
+	return js.As[*html.Navigator](cbCtx.Instance())
+}
+
+func navigatorUserAgent[T any](cbCtx js.CallbackContext[T]) (js.Value[T], error) {
+	nav, err := navigatorInstance(cbCtx)
+	if err != nil {
+		return nil, err
+	}
+	return cbCtx.NewString(nav.UserAgent()), nil
+}
+
+func navigatorPlatform[T any](cbCtx js.CallbackContext[T]) (js.Value[T], error) {
+	nav, err := navigatorInstance(cbCtx)
+	if err != nil {
+		return nil, err
+	}
+	return cbCtx.NewString(nav.Platform()), nil
+}
+
+func navigatorVendor[T any](cbCtx js.CallbackContext[T]) (js.Value[T], error) {
+	nav, err := navigatorInstance(cbCtx)
+	if err != nil {
+		return nil, err
+	}
+	return cbCtx.NewString(nav.Vendor()), nil
+}
+
+func navigatorLanguage[T any](cbCtx js.CallbackContext[T]) (js.Value[T], error) {
+	nav, err := navigatorInstance(cbCtx)
+	if err != nil {
+		return nil, err
+	}
+	return cbCtx.NewString(nav.Language()), nil
+}
+
+func navigatorLanguages[T any](cbCtx js.CallbackContext[T]) (js.Value[T], error) {
+	nav, err := navigatorInstance(cbCtx)
+	if err != nil {
+		return nil, err
+	}
+	langs := nav.Languages()
+	vals := make([]js.Value[T], len(langs))
+	for i, l := range langs {
+		vals[i] = cbCtx.NewString(l)
+	}
+	return cbCtx.NewArray(vals...), nil
+}
+
+func navigatorHardwareConcurrency[T any](cbCtx js.CallbackContext[T]) (js.Value[T], error) {
+	nav, err := navigatorInstance(cbCtx)
+	if err != nil {
+		return nil, err
+	}
+	return cbCtx.NewInt32(int32(nav.HardwareConcurrency())), nil
+}
+
+func navigatorWebdriver[T any](cbCtx js.CallbackContext[T]) (js.Value[T], error) {
+	nav, err := navigatorInstance(cbCtx)
+	if err != nil {
+		return nil, err
+	}
+	return cbCtx.NewBoolean(nav.Webdriver()), nil
+}

--- a/scripting/internal/scripttests/navigator_suite.go
+++ b/scripting/internal/scripttests/navigator_suite.go
@@ -1,0 +1,52 @@
+package scripttests
+
+import (
+	"testing"
+
+	"github.com/gost-dom/browser"
+	"github.com/gost-dom/browser/html"
+	"github.com/gost-dom/browser/internal/testing/browsertest"
+	"github.com/stretchr/testify/assert"
+)
+
+// testNavigator covers the configurable navigator surface: the default profile
+// reports sane values, and the browser-level WithNavigator option overrides
+// them.
+func testNavigator(t *testing.T, e html.ScriptEngine) {
+	t.Run("default profile", func(t *testing.T) {
+		win := browsertest.InitWindow(t, e)
+		eq := func(name, script string, want any) {
+			t.Helper()
+			assert.Equal(t, want, win.MustEval(script), name)
+		}
+		eq("userAgent non-empty", `navigator.userAgent.length > 0`, true)
+		eq("platform non-empty", `navigator.platform.length > 0`, true)
+		eq("vendor non-empty", `navigator.vendor.length > 0`, true)
+		eq("language non-empty", `navigator.language.length > 0`, true)
+		eq("languages is array", `Array.isArray(navigator.languages)`, true)
+		eq("language matches languages[0]", `navigator.language === navigator.languages[0]`, true)
+		eq("hardwareConcurrency positive",
+			`typeof navigator.hardwareConcurrency === "number" && navigator.hardwareConcurrency > 0`, true)
+		eq("webdriver false", `navigator.webdriver`, false)
+	})
+
+	t.Run("WithNavigator override", func(t *testing.T) {
+		win := browsertest.InitWindow(t, e, browsertest.WithBrowserOption(
+			browser.WithNavigator(html.NavigatorProfile{
+				UserAgent: "Custom/1.0",
+				Platform:  "TestOS",
+				Languages: []string{"de-DE", "de"},
+			}),
+		))
+		eq := func(name, script string, want any) {
+			t.Helper()
+			assert.Equal(t, want, win.MustEval(script), name)
+		}
+		eq("userAgent overridden", `navigator.userAgent`, "Custom/1.0")
+		eq("platform overridden", `navigator.platform`, "TestOS")
+		eq("languages overridden", `navigator.languages.join(",")`, "de-DE,de")
+		eq("language defaults to languages[0]", `navigator.language`, "de-DE")
+		// Unset fields fall back to the default profile.
+		eq("vendor falls back to default", `navigator.vendor.length > 0`, true)
+	})
+}

--- a/scripting/internal/scripttests/suites.go
+++ b/scripting/internal/scripttests/suites.go
@@ -54,6 +54,7 @@ func RunSuites(t *testing.T, e html.ScriptEngine) {
 	t.Run("NodeList", runSuite(NewNodeListSuite(e)))
 	t.Run("AbortController", runSuite(NewAbortControllerSuite(e)))
 	t.Run("Console", func(t *testing.T) { testConsole(t, e) })
+	t.Run("Navigator", func(t *testing.T) { testNavigator(t, e) })
 	t.Run("Fetch", func(t *testing.T) { testFetch(t, e) })
 	t.Run("Streams", func(t *testing.T) { testStreams(t, e) })
 	t.Run("CharacterData", func(t *testing.T) { testCharacterData(t, e) })


### PR DESCRIPTION
## Configurable navigator profile

Split out of #274, taking the approach suggested there: rather than hardcoding a
single browser identity in core, the values reported by navigator are
configurable per browser.

- html.NavigatorProfile holds the configurable fields (user agent, platform,
  vendor, language(s), hardware concurrency).
- browser.WithNavigator(profile) sets it; unset fields fall back to
  html.DefaultNavigatorProfile, which describes a current Chrome release so apps
  under test see a realistic, modern browser.
- The navigator data attributes read their values from the per-window
  html.Navigator instance, so each browser reports its own profile.

Tested in the shared script-engine suite (both V8 and Sobek), covering the
default profile and an override.

---
*AI disclosure:* This change was developed with the help of an AI coding assistant. I've reviewed and tested it myself; it follows the existing conventions and the full test suite (main module, `v8engine`, `sobekengine`) passes locally.
