### PR TITLE
feat(html): add performance, crypto and live document.readyState

### DIFF
--- a/html/html_document.go
+++ b/html/html_document.go
@@ -11,17 +11,34 @@ import (
 type HTMLDocument interface {
 	dom.Document
 	Location() Location
+	// ReadyState reports the document loading state: "loading" while the
+	// document is being parsed, and "complete" once parsing has finished.
+	ReadyState() string
 	// unexported
 	setActiveElement(e dom.Element)
 	location() *location
 	setLocation(*location)
+	setReadyState(string)
 	URL() string
 }
 
 type htmlDocument struct {
 	dom.Document
 	docLocation *location
+	readyState  string
 }
+
+// ReadyState reports the document loading state, defaulting to "loading" until
+// parsing completes and setReadyState records "complete".
+func (d *htmlDocument) ReadyState() string {
+	if d.readyState == "" {
+		return "loading"
+	}
+	return d.readyState
+}
+
+// setReadyState records the document's loading state (e.g. "complete").
+func (d *htmlDocument) setReadyState(s string) { d.readyState = s }
 
 func mustAppendChild(p, c dom.Node) dom.Node {
 	_, err := p.AppendChild(c)
@@ -68,7 +85,7 @@ func NewValidHTMLDocument(window Window, options ...func(HTMLDocument)) HTMLDocu
 
 // NewEmptyHtmlDocument creates an HTML document without any content.
 func NewEmptyHtmlDocument(window Window) HTMLDocument {
-	var result HTMLDocument = &htmlDocument{dom.NewDocument(window), nil}
+	var result HTMLDocument = &htmlDocument{Document: dom.NewDocument(window)}
 	entity.SetComponentType[Window](result, window)
 	result.SetSelf(result)
 	intdom.SetIsHTMLDocument(result, true)

--- a/html/window.go
+++ b/html/window.go
@@ -337,6 +337,11 @@ func (w *window) parseReader(reader io.Reader, u *url.URL) error {
 		s.run(w.Logger())
 	}
 	if err == nil {
+		// The document has finished parsing. Reflect this in readyState before
+		// dispatching the lifecycle events, so DOMContentLoaded handlers observe
+		// "complete"; and, crucially, so scripts that run *during* parsing
+		// observe "loading" and correctly defer their initialization.
+		w.document.setReadyState("complete")
 		w.document.DispatchEvent(&event.Event{Type: dom.DocumentEventDOMContentLoaded})
 		// 'load' is emitted when css and images are loaded, not relevant yet, so
 		// just emit it right await

--- a/scripting/internal/html/environment.go
+++ b/scripting/internal/html/environment.go
@@ -1,0 +1,203 @@
+package html
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/gost-dom/browser/html"
+	"github.com/gost-dom/browser/internal/entity"
+	codec "github.com/gost-dom/browser/scripting/internal/codec"
+	js "github.com/gost-dom/browser/scripting/internal/js"
+)
+
+// installEnvironment fills in functional parts of the browser environment that
+// the Web IDL code generator does not yet produce: the Performance and Crypto
+// interfaces (and their window accessors) and the live document.readyState.
+func installEnvironment[T any](e js.ScriptEngine[T]) {
+	configurePerformance(js.CreateClass(e, "Performance", "", js.IllegalConstructor))
+	configureCrypto(js.CreateClass(e, "Crypto", "", js.IllegalConstructor))
+
+	if win, ok := e.Class("Window"); ok {
+		win.CreateAttribute("performance", windowPerformance, nil)
+		win.CreateAttribute("crypto", windowCrypto, nil)
+	}
+	if doc, ok := e.Class("Document"); ok {
+		doc.CreateAttribute("readyState", documentReadyState, nil)
+	}
+}
+
+/* -------------------------------------------------------------------------- */
+/* performance                                                                */
+/* -------------------------------------------------------------------------- */
+
+type performanceObj struct {
+	entity.Entity
+	origin time.Time
+}
+
+func configurePerformance[T any](performance js.Class[T]) {
+	performance.CreateOperation("now", performanceNow)
+	performance.CreateAttribute("timeOrigin", performanceTimeOrigin, nil)
+}
+
+func performanceNow[T any](cbCtx js.CallbackContext[T]) (js.Value[T], error) {
+	inst, err := js.As[*performanceObj](cbCtx.Instance())
+	if err != nil {
+		return nil, err
+	}
+	ms := float64(time.Since(inst.origin).Nanoseconds()) / 1e6
+	return cbCtx.NewNumber(ms), nil
+}
+
+func performanceTimeOrigin[T any](cbCtx js.CallbackContext[T]) (js.Value[T], error) {
+	inst, err := js.As[*performanceObj](cbCtx.Instance())
+	if err != nil {
+		return nil, err
+	}
+	return cbCtx.NewNumber(float64(inst.origin.UnixNano()) / 1e6), nil
+}
+
+func windowPerformance[T any](cbCtx js.CallbackContext[T]) (js.Value[T], error) {
+	win, err := codec.GetWindow(cbCtx)
+	if err != nil {
+		return nil, err
+	}
+	p, ok := entity.ComponentType[*performanceObj](win)
+	if !ok {
+		p = &performanceObj{origin: time.Now()}
+		entity.SetComponentType(win, p)
+	}
+	return codec.EncodeEntityScopedWithPrototype(cbCtx, p, "Performance")
+}
+
+/* -------------------------------------------------------------------------- */
+/* crypto                                                                     */
+/* -------------------------------------------------------------------------- */
+
+type cryptoObj struct{ entity.Entity }
+
+func configureCrypto[T any](crypto js.Class[T]) {
+	crypto.CreateOperation("getRandomValues", cryptoGetRandomValues)
+	crypto.CreateOperation("randomUUID", cryptoRandomUUID)
+}
+
+func windowCrypto[T any](cbCtx js.CallbackContext[T]) (js.Value[T], error) {
+	win, err := codec.GetWindow(cbCtx)
+	if err != nil {
+		return nil, err
+	}
+	c, ok := entity.ComponentType[*cryptoObj](win)
+	if !ok {
+		c = &cryptoObj{}
+		entity.SetComponentType(win, c)
+	}
+	return codec.EncodeEntityScopedWithPrototype(cbCtx, c, "Crypto")
+}
+
+// cryptoGetRandomValues fills the passed integer TypedArray with
+// cryptographically-strong random values and returns the same array, matching
+// Crypto.getRandomValues.
+func cryptoGetRandomValues[T any](cbCtx js.CallbackContext[T]) (js.Value[T], error) {
+	args := cbCtx.Args()
+	if len(args) == 0 {
+		return nil, cbCtx.NewTypeError("Crypto.getRandomValues: 1 argument required")
+	}
+	arg := args[0]
+	obj, ok := arg.AsObject()
+	if !ok {
+		return nil, cbCtx.NewTypeError("Crypto.getRandomValues: argument is not an object")
+	}
+	bpeVal, err := obj.Get("BYTES_PER_ELEMENT")
+	if err != nil {
+		return nil, err
+	}
+	bpe := int(bpeVal.Int32())
+	if bpe == 0 || bpe > 4 {
+		// bpe==0 is a non-TypedArray; >4-byte elements are BigInt64/BigUint64
+		// arrays, which need BigInt values this implementation does not produce.
+		return nil, cbCtx.NewTypeError(
+			"Crypto.getRandomValues: argument is not an integer TypedArray of <= 32-bit elements")
+	}
+	// Float typed arrays (e.g. Float32Array, which also has a 4-byte element)
+	// must be rejected with a TypeMismatchError per the spec, not filled.
+	if isFloatTypedArray(cbCtx, obj) {
+		return nil, cbCtx.NewTypeError(
+			"Crypto.getRandomValues: argument is not an integer TypedArray")
+	}
+	lengthVal, err := obj.Get("length")
+	if err != nil {
+		return nil, err
+	}
+	n := int(lengthVal.Int32())
+	if n*bpe > 65536 {
+		return nil, cbCtx.NewError(fmt.Errorf("Crypto.getRandomValues: array exceeds 65536 byte quota"))
+	}
+	raw := make([]byte, n*4)
+	if _, err := rand.Read(raw); err != nil {
+		return nil, cbCtx.NewError(err)
+	}
+	for i := 0; i < n; i++ {
+		// The engine truncates the assigned Number to the element width, so a
+		// random uint32 yields uniform random bits for 8-, 16- and 32-bit
+		// elements.
+		v := binary.LittleEndian.Uint32(raw[i*4:])
+		if err := obj.Set(strconv.Itoa(i), cbCtx.NewUint32(v)); err != nil {
+			return nil, err
+		}
+	}
+	return arg, nil
+}
+
+// isFloatTypedArray reports whether obj is a Float16/32/64 typed array, whose
+// elements getRandomValues must reject. It compares the array's constructor to
+// the global float typed-array constructors. This works regardless of whether
+// the engine lets a constructor function be introspected as an object (Sobek
+// does not), unlike reading constructor.name.
+func isFloatTypedArray[T any](cbCtx js.CallbackContext[T], obj js.Object[T]) bool {
+	ctor, err := obj.Get("constructor")
+	if err != nil || ctor == nil {
+		return false
+	}
+	globalThis := cbCtx.GlobalThis()
+	for _, name := range []string{"Float16Array", "Float32Array", "Float64Array"} {
+		floatCtor, err := globalThis.Get(name)
+		if err != nil || floatCtor == nil || floatCtor.IsUndefined() {
+			continue
+		}
+		if ctor.StrictEquals(floatCtor) {
+			return true
+		}
+	}
+	return false
+}
+
+// cryptoRandomUUID implements crypto.randomUUID, returning a random RFC 4122
+// version 4 UUID string.
+func cryptoRandomUUID[T any](cbCtx js.CallbackContext[T]) (js.Value[T], error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return nil, cbCtx.NewError(err)
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	uuid := fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+	return cbCtx.NewString(uuid), nil
+}
+
+/* -------------------------------------------------------------------------- */
+/* document                                                                   */
+/* -------------------------------------------------------------------------- */
+
+// documentReadyState returns the owning document's real load state ("loading"
+// while parsing, "complete" afterwards) rather than a constant, so scripts that
+// defer work until the DOM is ready behave correctly.
+func documentReadyState[T any](cbCtx js.CallbackContext[T]) (js.Value[T], error) {
+	doc, err := js.As[html.HTMLDocument](cbCtx.Instance())
+	if err != nil {
+		return cbCtx.NewString("complete"), nil
+	}
+	return cbCtx.NewString(doc.ReadyState()), nil
+}

--- a/scripting/internal/html/initializer.go
+++ b/scripting/internal/html/initializer.go
@@ -22,6 +22,7 @@ func ConfigureScriptEngine[T any](e js.ScriptEngine[T]) {
 	// See also: https://developer.mozilla.org/en-US/docs/Web/API/HTMLDocument
 	js.CreateClass(e, "HTMLDocument", "Document", js.IllegalConstructor)
 	installHtmlElementTypes(e)
+	installEnvironment(e)
 }
 
 // installHtmlElementTypes adds classes for all the HTML element types work which

--- a/scripting/internal/scripttests/environment_suite.go
+++ b/scripting/internal/scripttests/environment_suite.go
@@ -1,0 +1,46 @@
+package scripttests
+
+import (
+	"testing"
+
+	"github.com/gost-dom/browser/html"
+	"github.com/gost-dom/browser/internal/testing/browsertest"
+	"github.com/stretchr/testify/assert"
+)
+
+// testEnvironment covers the functional browser-environment surface:
+// performance, crypto and the live document.readyState.
+func testEnvironment(t *testing.T, e html.ScriptEngine) {
+	win := browsertest.InitWindow(t, e)
+	eq := func(name, script string, want any) {
+		t.Helper()
+		assert.Equal(t, want, win.MustEval(script), name)
+	}
+
+	t.Run("performance", func(t *testing.T) {
+		eq("now is number", `typeof performance.now() === "number"`, true)
+		eq("now monotonic",
+			`(() => { const a = performance.now(); const b = performance.now(); return b >= a; })()`, true)
+		eq("timeOrigin positive",
+			`typeof performance.timeOrigin === "number" && performance.timeOrigin > 0`, true)
+	})
+
+	t.Run("crypto", func(t *testing.T) {
+		eq("getRandomValues returns same array",
+			`(() => { const a = new Uint8Array(16); return crypto.getRandomValues(a) === a; })()`, true)
+		eq("getRandomValues fills",
+			`(() => { const a = new Uint8Array(32); crypto.getRandomValues(a); return a.some(x => x !== 0); })()`, true)
+		eq("randomUUID format",
+			`/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(crypto.randomUUID())`, true)
+		eq("rejects Float32Array",
+			`(() => { try { crypto.getRandomValues(new Float32Array(4)); return false; } catch (e) { return true; } })()`, true)
+	})
+
+	t.Run("document.readyState", func(t *testing.T) {
+		eq("is a string", `typeof document.readyState === "string"`, true)
+		// A freshly parsed document reports "complete".
+		w := browsertest.InitWindow(t, e)
+		assert.NoError(t, w.LoadHTML(`<html><body></body></html>`))
+		assert.Equal(t, "complete", w.MustEval(`document.readyState`), "readyState after load")
+	})
+}

--- a/scripting/internal/scripttests/suites.go
+++ b/scripting/internal/scripttests/suites.go
@@ -54,6 +54,7 @@ func RunSuites(t *testing.T, e html.ScriptEngine) {
 	t.Run("NodeList", runSuite(NewNodeListSuite(e)))
 	t.Run("AbortController", runSuite(NewAbortControllerSuite(e)))
 	t.Run("Console", func(t *testing.T) { testConsole(t, e) })
+	t.Run("Environment", func(t *testing.T) { testEnvironment(t, e) })
 	t.Run("Fetch", func(t *testing.T) { testFetch(t, e) })
 	t.Run("Streams", func(t *testing.T) { testStreams(t, e) })
 	t.Run("CharacterData", func(t *testing.T) { testCharacterData(t, e) })


### PR DESCRIPTION
## performance, crypto, and live document.readyState

Split out of #274 - the functional environment APIs that the Web IDL generator
does not yet produce:

- performance.now() and performance.timeOrigin
- crypto.getRandomValues() and crypto.randomUUID()
- document.readyState, reflecting the real load state ("loading" while parsing,
  "complete" afterwards) so scripts that defer work until the DOM is ready
  behave correctly

getRandomValues rejects float typed arrays by comparing the array's constructor
against the global float constructors, which works on both engines (Sobek does
not let a constructor function be introspected as an object, so constructor.name
through the abstraction is not reliable). Tested in the shared suite across V8
and Sobek.

One thing worth flagging: performance.now() currently measures against
wall-clock time.Now(), not the simulated clock. Happy to wire it to the clock
if you would prefer simulated time to drive it - was not sure whether
performance should advance with simulated time.

screen, the window viewport metrics, and the document string constants from the
original PR are deliberately left out for now.

---
*AI disclosure:* This change was developed with the help of an AI coding assistant. I've reviewed and tested it myself; it follows the existing conventions and the full test suite (main module, `v8engine`, `sobekengine`) passes locally.
