### PR TITLE
feat: dispatch hashchange on location.hash assignment

### DIFF
--- a/html/html_document.go
+++ b/html/html_document.go
@@ -112,8 +112,17 @@ func (d *htmlDocument) Location() Location {
 	return d.docLocation
 }
 
-func (d *htmlDocument) location() *location     { return d.docLocation }
-func (d *htmlDocument) setLocation(l *location) { d.docLocation = l }
+func (d *htmlDocument) location() *location { return d.docLocation }
+func (d *htmlDocument) setLocation(l *location) {
+	// Give the location a back-reference to the owning window so a same-document
+	// fragment change (location.hash = ...) can dispatch a hashchange event.
+	if l != nil {
+		if w, ok := entity.ComponentType[Window](d); ok && w != nil {
+			l.win = w.window()
+		}
+	}
+	d.docLocation = l
+}
 func (d *htmlDocument) URL() string {
 	if location := d.Location(); location != nil {
 		return location.Href()

--- a/html/location.go
+++ b/html/location.go
@@ -3,14 +3,33 @@ package html
 import (
 	"fmt"
 
+	"github.com/gost-dom/browser/dom/event"
 	"github.com/gost-dom/browser/internal/constants"
 	"github.com/gost-dom/browser/internal/entity"
 	"github.com/gost-dom/browser/url"
 )
 
+// HistoryEventHashChange is fired at the window when the URL fragment changes as
+// a same-document navigation (e.g. `location.hash = ...`).
+const HistoryEventHashChange = "hashchange"
+
+// HashChangeEventInit carries the fully-qualified URLs before and after the
+// fragment change, matching the HashChangeEvent interface.
+//
+// See also: https://developer.mozilla.org/en-US/docs/Web/API/HashChangeEvent
+type HashChangeEventInit struct {
+	OldURL string
+	NewURL string
+}
+
 type location struct {
 	entity.Entity
 	*url.URL
+	// win is the owning window, set when the document adopts this location, so a
+	// same-document navigation (SetHash) can dispatch a hashchange event. It may
+	// be nil for a detached location, in which case SetHash mutates the URL
+	// silently (as before).
+	win *window
 }
 
 func urlToLocation(u *url.URL) *location {
@@ -21,6 +40,25 @@ func urlToLocation(u *url.URL) *location {
 }
 
 func (l *location) set(u *url.URL) { l.URL = u }
+
+// SetHash implements the `location.hash` setter as a same-document navigation:
+// it updates the fragment and, if the fragment actually changed, fires a
+// hashchange event at the owning window. This overrides the SetHash promoted
+// from the embedded *url.URL (which only mutates the URL).
+func (l *location) SetHash(val string) {
+	oldURL := l.URL.Href()
+	oldHash := l.URL.Hash()
+	l.URL.SetHash(val)
+	if l.URL.Hash() == oldHash {
+		return // no change → no event (per spec)
+	}
+	if l.win != nil {
+		l.win.DispatchEvent(&event.Event{
+			Type: HistoryEventHashChange,
+			Data: HashChangeEventInit{OldURL: oldURL, NewURL: l.URL.Href()},
+		})
+	}
+}
 
 func (l location) AncestorOrigins() DOMStringList {
 	return nil

--- a/html/location_hashchange_test.go
+++ b/html/location_hashchange_test.go
@@ -1,0 +1,54 @@
+package html_test
+
+import (
+	"testing"
+
+	"github.com/gost-dom/browser/dom/event"
+	"github.com/gost-dom/browser/html"
+	"github.com/gost-dom/browser/internal/testing/browsertest"
+	"github.com/stretchr/testify/assert"
+)
+
+// Setting location.hash is a same-document navigation: it must normalize the
+// fragment (strip one leading '#') and fire a hashchange event at the window.
+func TestLocationHashSetterFiresHashChange(t *testing.T) {
+	b := browsertest.InitBrowser(t, nil, nil)
+	win := b.OpenWindow("http://example.com/index")
+
+	fired := 0
+	win.AddEventListener("hashchange", event.NewEventHandlerFunc(func(e *event.Event) error {
+		fired++
+		return nil
+	}))
+
+	win.Location().SetHash("#/login")
+
+	// Normalized: reads back as "#/login", not "##/login".
+	assert.Equal(t, "#/login", win.Location().Hash())
+	assert.Equal(t, "http://example.com/index#/login", win.Location().Href(), "single # in href")
+	assert.Equal(t, 1, fired, "hashchange should fire once")
+
+	// Setting the same hash again fires nothing (no change).
+	win.Location().SetHash("#/login")
+	assert.Equal(t, 1, fired, "identical hash must not re-fire")
+
+	// A different hash fires again.
+	win.Location().SetHash("#/home")
+	assert.Equal(t, 2, fired)
+}
+
+// The event carries oldURL/newURL per the HashChangeEvent interface.
+func TestHashChangeEventURLs(t *testing.T) {
+	b := browsertest.InitBrowser(t, nil, nil)
+	win := b.OpenWindow("http://example.com/index")
+
+	var got html.HashChangeEventInit
+	win.AddEventListener("hashchange", event.NewEventHandlerFunc(func(e *event.Event) error {
+		got, _ = e.Data.(html.HashChangeEventInit)
+		return nil
+	}))
+
+	win.Location().SetHash("#/next")
+	assert.Equal(t, "http://example.com/index", got.OldURL)
+	assert.Equal(t, "http://example.com/index#/next", got.NewURL)
+}

--- a/url/url.go
+++ b/url/url.go
@@ -136,7 +136,10 @@ func (l *URL) SetUsername(
 func (l URL) Username() string                { return l.url.User.Username() }
 func (l *URL) SearchParams() *URLSearchParams { return &URLSearchParams{l.url.Query(), l} }
 
-func (l *URL) SetHash(val string) { l.url.Fragment = val }
+// SetHash sets the URL fragment. Per the URL spec, a single leading "#" in the
+// assigned value is stripped (so `location.hash = "#/x"` yields fragment "/x",
+// and Hash() reads back "#/x", not "##/x").
+func (l *URL) SetHash(val string) { l.url.Fragment = strings.TrimPrefix(val, "#") }
 func (l *URL) SetHost(val string) { l.url.Host = val }
 func (l *URL) SetHostname(val string) {
 	port := l.Port()


### PR DESCRIPTION
Assigning `location.hash` is a same-document navigation. Two gaps meant it silently did neither the normalization nor the event:

- url.SetHash stored the value verbatim, so `location.hash = "#/x"` read back as "##/x" (Hash() re-prepends '#'). Per the URL spec, a single leading '#' is stripped on assignment.

- Assigning the hash fired no `hashchange` event, so hash-routed SPAs (which listen for it) never reacted to programmatic navigation.

location now overrides SetHash: it normalizes via url.SetHash and, when the fragment actually changes, dispatches a hashchange event (HashChangeEventInit{OldURL, NewURL}) at the owning window. The window is resolved through the document's Window entity component, set as a back-reference when the document adopts the location. A detached location (no window) mutates silently, as before. Setting the same hash is a no-op, matching the spec.

This complements the existing pushState behavior, which already declined to emit hashchange for a fragment (see TestPushStateWithFragment).