### PR TITLE
feat: implement Response.ok/statusText, Body.text; fix empty headers init

### DIFF
--- a/internal/code-gen/scripting/configuration/fetch_configuration.go
+++ b/internal/code-gen/scripting/configuration/fetch_configuration.go
@@ -16,14 +16,19 @@ func configureFetchSpecs(specs *WebAPIConfig) {
 	res.OverrideWrappedType = &GoType{Package: packagenames.Fetch, Name: "Response", Pointer: true}
 	res.SkipConstructor = true
 	res.MarkMembersAsNotImplemented(
-		"type", "clone", "url", "redirected", "ok", "statusText",
+		"type", "clone", "url", "redirected",
 	)
+	// ok and statusText have hand-written implementations in response.go.
+	res.Method("ok").SetCustomImplementation()
+	res.Method("statusText").SetCustomImplementation()
 
 	body := specs.Type("Body")
 	body.MarkMembersAsNotImplemented(
-		"arrayBuffer", "blob", "bytes", "formData", "text", "bodyUsed",
+		"arrayBuffer", "blob", "bytes", "formData", "bodyUsed",
 	)
 	body.Method("json").SetCustomImplementation()
+	// text has a hand-written implementation in body.go.
+	body.Method("text").SetCustomImplementation()
 
 	headers := specs.Type("Headers")
 	headers.MarkMembersAsNotImplemented("getSetCookie")

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -152,6 +152,13 @@ type Response struct {
 	httpResponse *http.Response
 }
 
+// Ok reports whether Status is in the 2xx range (Response.ok).
+func (r *Response) Ok() bool { return r.Status >= 200 && r.Status <= 299 }
+
+// StatusText returns the reason phrase for the status code, e.g. "Not Found"
+// (Response.statusText).
+func (r *Response) StatusText() string { return http.StatusText(r.Status) }
+
 type ReadableStream struct {
 	Reader io.Reader
 }

--- a/scripting/internal/fetch/body.go
+++ b/scripting/internal/fetch/body.go
@@ -16,8 +16,20 @@ func Body_json[T any](cbCtx js.CallbackContext[T]) (res js.Value[T], err error) 
 	return codec.EncodePromise(cbCtx, promise.ReadAll(instance), EncodeJSONBytes)
 }
 
+func Body_text[T any](cbCtx js.CallbackContext[T]) (res js.Value[T], err error) {
+	instance, err := js.As[fetch.Body](cbCtx.Instance())
+	if err != nil {
+		return nil, err
+	}
+	return codec.EncodePromise(cbCtx, promise.ReadAll(instance), EncodeTextBytes)
+}
+
 func EncodeJSONBytes[T any](scope js.Scope[T], b []byte) (js.Value[T], error) {
 	return scope.JSONParse(string(b))
+}
+
+func EncodeTextBytes[T any](scope js.Scope[T], b []byte) (js.Value[T], error) {
+	return codec.EncodeString(scope, string(b))
 }
 
 func encodeReadableStream[T any](

--- a/scripting/internal/fetch/body_generated.go
+++ b/scripting/internal/fetch/body_generated.go
@@ -35,10 +35,6 @@ func Body_formData[T any](cbCtx js.CallbackContext[T]) (res js.Value[T], err err
 	return codec.EncodeCallbackErrorf(cbCtx, "Body.Body_formData: Not implemented. Create an issue: https://github.com/gost-dom/browser/issues")
 }
 
-func Body_text[T any](cbCtx js.CallbackContext[T]) (res js.Value[T], err error) {
-	return codec.EncodeCallbackErrorf(cbCtx, "Body.Body_text: Not implemented. Create an issue: https://github.com/gost-dom/browser/issues")
-}
-
 func Body_body[T any](cbCtx js.CallbackContext[T]) (res js.Value[T], err error) {
 	instance, err := js.As[fetch.Body](cbCtx.Instance())
 	if err != nil {

--- a/scripting/internal/fetch/headers.go
+++ b/scripting/internal/fetch/headers.go
@@ -35,6 +35,11 @@ func decodeHeadersInit[T any](
 		return
 	}
 	if obj, ok := v.AsObject(); ok {
+		// Not iterable → treat as a plain record of name/value pairs. Clear the
+		// sentinel first: for an EMPTY object the loop below never assigns err,
+		// so the stale ErrNotIterable would leak out as the result (making
+		// `fetch(url, {headers: {}})` fail while `{headers: {a: "b"}}` worked).
+		err = nil
 		var key js.Value[T]
 		for key, err = range js.ObjectEnumerableOwnPropertyKeys(scope, obj) {
 			if err == nil && key.IsSymbol() {

--- a/scripting/internal/fetch/response.go
+++ b/scripting/internal/fetch/response.go
@@ -3,9 +3,27 @@ package fetch
 import (
 	"fmt"
 
+	"github.com/gost-dom/browser/internal/fetch"
+	"github.com/gost-dom/browser/scripting/internal/codec"
 	"github.com/gost-dom/browser/scripting/internal/js"
 )
 
 func ResponseConstructor[T any](cbCtx js.CallbackContext[T]) (js.Value[T], error) {
 	return nil, fmt.Errorf("gost-dom/fetch: Response constructor not implemented")
+}
+
+func Response_ok[T any](cbCtx js.CallbackContext[T]) (res js.Value[T], err error) {
+	instance, err := js.As[*fetch.Response](cbCtx.Instance())
+	if err != nil {
+		return nil, err
+	}
+	return codec.EncodeBoolean(cbCtx, instance.Ok())
+}
+
+func Response_statusText[T any](cbCtx js.CallbackContext[T]) (res js.Value[T], err error) {
+	instance, err := js.As[*fetch.Response](cbCtx.Instance())
+	if err != nil {
+		return nil, err
+	}
+	return codec.EncodeString(cbCtx, instance.StatusText())
 }

--- a/scripting/internal/fetch/response_generated.go
+++ b/scripting/internal/fetch/response_generated.go
@@ -45,14 +45,6 @@ func Response_status[T any](cbCtx js.CallbackContext[T]) (res js.Value[T], err e
 	return codec.EncodeInt(cbCtx, result)
 }
 
-func Response_ok[T any](cbCtx js.CallbackContext[T]) (res js.Value[T], err error) {
-	return codec.EncodeCallbackErrorf(cbCtx, "Response.Response_ok: Not implemented. Create an issue: https://github.com/gost-dom/browser/issues")
-}
-
-func Response_statusText[T any](cbCtx js.CallbackContext[T]) (res js.Value[T], err error) {
-	return codec.EncodeCallbackErrorf(cbCtx, "Response.Response_statusText: Not implemented. Create an issue: https://github.com/gost-dom/browser/issues")
-}
-
 func Response_headers[T any](cbCtx js.CallbackContext[T]) (res js.Value[T], err error) {
 	instance, err := js.As[*fetch.Response](cbCtx.Instance())
 	if err != nil {

--- a/scripting/internal/scripttests/fetch_suite.go
+++ b/scripting/internal/scripttests/fetch_suite.go
@@ -36,6 +36,8 @@ func testFetch(t *testing.T, e html.ScriptEngine) {
 	t.Run("Fetch resource async/await", func(t *testing.T) { testFetchJSONAsync(t, e) })
 	t.Run("Fetch invalid JSON", func(t *testing.T) { testFetchInvalidJSON(t, e) })
 	t.Run("404 for not found resource", func(t *testing.T) { testNotFound(t, e) })
+	t.Run("RequestInit with empty headers object", func(t *testing.T) { testEmptyHeadersInit(t, e) })
+	t.Run("Response ok/statusText/text", func(t *testing.T) { testResponseOkStatusTextText(t, e) })
 	t.Run("ReadableStream body", func(t *testing.T) { testReadableStream(t, e) })
 	t.Run("Headers", func(t *testing.T) { testHeaders(t, e) })
 	t.Run("Request", func(t *testing.T) { testRequest(t, e) })
@@ -387,6 +389,58 @@ func testNotFound(t *testing.T, e html.ScriptEngine) {
 	defer cancel()
 	assert.NoError(t, win.Clock().ProcessEvents(ctx))
 	g.Expect(win.Eval("got")).To(BeEquivalentTo(404))
+}
+
+// Regression: a plain-object headers init must work even when EMPTY. A stale
+// ErrNotIterable from the iterator attempt used to leak out of the record
+// fallback when the loop had zero entries, so `fetch(url, {headers: {}})`
+// rejected while `{headers: {a: "b"}}` succeeded.
+func testEmptyHeadersInit(t *testing.T, e html.ScriptEngine) {
+	handler := gosttest.HttpHandlerMap{
+		"/index.html": gosttest.StaticHTML(`<body>dummy</body>`),
+		"/data.json":  gosttest.StaticJSON(`{"foo": "bar"}`),
+	}
+	g := gomega.NewWithT(t)
+	win := openWindow(t, e, handler, "https://example.com/index.html")
+	win.MustRun(`
+		fetch("data.json", { method: "GET", headers: {} })
+			.then(r => { globalThis.got = r.status }, e => { globalThis.failed = String(e) })
+	`)
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	assert.NoError(t, win.Clock().ProcessEvents(ctx))
+	g.Expect(win.Eval("globalThis.failed")).To(BeNil(), "fetch with empty headers object rejected")
+	g.Expect(win.Eval("got")).To(BeEquivalentTo(200))
+}
+
+// Response.ok, Response.statusText, and Body.text().
+func testResponseOkStatusTextText(t *testing.T, e html.ScriptEngine) {
+	handler := gosttest.HttpHandlerMap{
+		"/index.html": gosttest.StaticHTML(`<body>dummy</body>`),
+		"/data.txt":   gosttest.StaticJSON(`hello`),
+	}
+	g := gomega.NewWithT(t)
+	win := openWindow(t, e, handler, "https://example.com/index.html")
+	win.MustRun(`
+		(async () => {
+			const r = await fetch("data.txt")
+			globalThis.gotOk = r.ok
+			globalThis.gotStatusText = r.statusText
+			globalThis.gotText = await r.text()
+			const missing = await fetch("nope.txt")
+			globalThis.missingOk = missing.ok
+			globalThis.missingStatusText = missing.statusText
+		})().catch(e => { globalThis.failed = String(e) })
+	`)
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	assert.NoError(t, win.Clock().ProcessEvents(ctx))
+	g.Expect(win.Eval("globalThis.failed")).To(BeNil())
+	g.Expect(win.Eval("gotOk")).To(BeEquivalentTo(true), "ok for 200")
+	g.Expect(win.Eval("gotStatusText")).To(Equal("OK"))
+	g.Expect(win.Eval("gotText")).To(Equal(`hello`))
+	g.Expect(win.Eval("missingOk")).To(BeEquivalentTo(false), "ok for 404")
+	g.Expect(win.Eval("missingStatusText")).To(Equal("Not Found"))
 }
 
 func testReadableStream(t *testing.T, e html.ScriptEngine) {


### PR DESCRIPTION
Filling fetch gaps hit when driving a real app's request/response flow:

- Response.ok and Response.statusText were "Not implemented" stubs. Added Ok() (status 200-299) and StatusText() (net/http reason phrase) to the Go Response, and hand-written bindings in response.go mirroring Response_status.

- Body.text() was a stub. Added it in body.go mirroring Body_json, reading the body and resolving the promise with a string.

- Bugfix: `fetch(url, {headers: {}})` rejected with "value not iterable" while `{headers: {a: "b"}}` worked. decodeHeadersInit's plain-record fallback reuses the named return err, which still held the ErrNotIterable sentinel from the iterator attempt; an EMPTY object never reassigns it in the loop, so the stale sentinel leaked out. Clear it entering the fallback.

Tests: two new fetch-suite subtests, "RequestInit with empty headers object" (regression) and "Response ok/statusText/text".