### PR TITLE
feat(html): include select and textarea in form data set

### DIFF
--- a/html/form_data.go
+++ b/html/form_data.go
@@ -35,6 +35,9 @@ func NewFormDataForm(form HTMLFormElement) *FormData {
 	elements := form.Elements()
 	formData := NewFormData()
 	for el := range elements.All() {
+		if domEl, ok := el.(dom.Element); ok && isDisabledControl(domEl) {
+			continue
+		}
 		if input, ok := el.(HTMLInputElement); ok {
 			name := input.Name()
 			if name == "" {
@@ -73,6 +76,55 @@ func NewFormDataForm(form HTMLFormElement) *FormData {
 	return formData
 }
 
+// isDisabledControl reports whether a form control is barred from the form
+// data set because it is disabled -- either by its own attribute, or by
+// sitting inside a disabled <fieldset>.
+//
+// The fieldset rule has an exception: controls inside that fieldset's *first*
+// <legend> stay enabled, so a disabled fieldset can still carry a working
+// control in its caption.
+//
+// see https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-form-data-set
+// and https://html.spec.whatwg.org/multipage/form-elements.html#concept-fieldset-disabled
+func isDisabledControl(el dom.Element) bool {
+	if _, disabled := el.GetAttribute("disabled"); disabled {
+		return true
+	}
+	fieldset, err := el.Closest("fieldset[disabled]")
+	if err != nil || fieldset == nil {
+		return false
+	}
+	// Inside a disabled fieldset. Exempt only if the control sits within that
+	// fieldset's first legend child.
+	legend := firstLegendChild(fieldset)
+	if legend == nil {
+		return true
+	}
+	for anc := el.ParentElement(); anc != nil; anc = anc.ParentElement() {
+		if anc == legend {
+			return false
+		}
+		if anc == fieldset {
+			break
+		}
+	}
+	return true
+}
+
+// firstLegendChild returns a fieldset's first direct <legend> child, or nil.
+func firstLegendChild(fieldset dom.Element) dom.Element {
+	parent, ok := fieldset.(dom.ParentNode)
+	if !ok {
+		return nil
+	}
+	for _, child := range parent.Children().All() {
+		if child.TagName() == "LEGEND" {
+			return child
+		}
+	}
+	return nil
+}
+
 // selectValues returns the values a <select> contributes to the form data set:
 // one entry per selected <option>, in document order.
 //
@@ -83,7 +135,11 @@ func NewFormDataForm(form HTMLFormElement) *FormData {
 //     select the user never touched.
 //   - A select with no options contributes nothing either way.
 //
-// An option with no "value" attribute contributes its text content, per
+// Disabled options, and options inside a disabled <optgroup>, are skipped
+// entirely -- they can be neither selected nor used as the fallback.
+//
+// An option with no "value" attribute contributes its text content with ASCII
+// whitespace stripped and collapsed, per
 // https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-value
 func selectValues(sel dom.Element) []string {
 	parent, ok := sel.(dom.ParentNode)
@@ -105,9 +161,12 @@ func selectValues(sel dom.Element) []string {
 		if !ok {
 			continue
 		}
+		if isDisabledOption(opt) {
+			continue
+		}
 		val, hasVal := opt.GetAttribute("value")
 		if !hasVal {
-			val = opt.TextContent()
+			val = collapseASCIIWhitespace(opt.TextContent())
 		}
 		if !hasFirst {
 			firstValue, hasFirst = val, true
@@ -124,9 +183,35 @@ func selectValues(sel dom.Element) []string {
 		return selected
 	}
 	if !hasFirst {
-		return nil // no options at all
+		return nil // no options at all, or all of them disabled
 	}
 	return []string{firstValue}
+}
+
+// isDisabledOption reports whether an <option> is unselectable: disabled
+// itself, or inside a disabled <optgroup>.
+func isDisabledOption(opt dom.Element) bool {
+	if _, disabled := opt.GetAttribute("disabled"); disabled {
+		return true
+	}
+	group, err := opt.Closest("optgroup[disabled]")
+	return err == nil && group != nil
+}
+
+// collapseASCIIWhitespace strips leading/trailing ASCII whitespace and
+// collapses interior runs to a single space, which is what an <option>'s
+// text-derived value is normalised to. Templates indent their options, so
+// without this a value arrives wrapped in the markup's newlines and tabs.
+func collapseASCIIWhitespace(s string) string {
+	return strings.Join(strings.FieldsFunc(s, isASCIIWhitespace), " ")
+}
+
+func isASCIIWhitespace(r rune) bool {
+	switch r {
+	case ' ', '\t', '\n', '\r', '\f':
+		return true
+	}
+	return false
 }
 
 func (d *FormData) AddElement(e dom.Element) {

--- a/html/form_data.go
+++ b/html/form_data.go
@@ -46,9 +46,18 @@ func NewFormDataForm(form HTMLFormElement) *FormData {
 			switch input.Type() {
 			case "submit":
 				continue
-			case "checkbox":
+			case "checkbox", "radio":
+				// Only checked controls contribute, and they contribute their
+				// value attribute -- "on" is merely the default when no value
+				// was given, not a replacement for one.
+				//
+				// see https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox):concept-fe-value
 				if input.Checked() {
-					formData.Append(name, "on")
+					value := input.Value()
+					if value == "" {
+						value = "on"
+					}
+					formData.Append(name, NewFormDataValueString(value))
 				}
 			default:
 				// TODO: handle no values

--- a/html/form_data.go
+++ b/html/form_data.go
@@ -32,10 +32,10 @@ func NewFormData() *FormData {
 //
 // see also: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-form-data-set
 func NewFormDataForm(form HTMLFormElement) *FormData {
-	inputs := form.Elements()
+	elements := form.Elements()
 	formData := NewFormData()
-	for input := range inputs.All() {
-		if input, ok := input.(HTMLInputElement); ok {
+	for el := range elements.All() {
+		if input, ok := el.(HTMLInputElement); ok {
 			name := input.Name()
 			if name == "" {
 				continue
@@ -51,9 +51,59 @@ func NewFormDataForm(form HTMLFormElement) *FormData {
 				// TODO: handle no values
 				formData.Append(name, NewFormDataValueString(input.Value()))
 			}
+			continue
+		}
+		// <select> and <textarea> have no specialized DOM types yet, so read
+		// their name/value from the element directly.
+		if domEl, ok := el.(dom.Element); ok {
+			name, hasName := domEl.GetAttribute("name")
+			if !hasName || name == "" {
+				continue
+			}
+			switch domEl.TagName() {
+			case "SELECT":
+				formData.Append(name, NewFormDataValueString(selectValue(domEl)))
+			case "TEXTAREA":
+				formData.Append(name, NewFormDataValueString(domEl.TextContent()))
+			}
 		}
 	}
 	return formData
+}
+
+// selectValue returns the value of the first <option> carrying the "selected"
+// attribute, falling back to the first option -- which is what a browser
+// submits for a select the user never touched.
+//
+// An option with no "value" attribute submits its text content, per
+// https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-value
+func selectValue(sel dom.Element) string {
+	parent, ok := sel.(dom.ParentNode)
+	if !ok {
+		return ""
+	}
+	options, err := parent.QuerySelectorAll("option")
+	if err != nil {
+		return ""
+	}
+	firstValue := ""
+	for i := 0; i < options.Length(); i++ {
+		opt, ok := options.Item(i).(dom.Element)
+		if !ok {
+			continue
+		}
+		val, hasVal := opt.GetAttribute("value")
+		if !hasVal {
+			val = opt.TextContent()
+		}
+		if i == 0 {
+			firstValue = val
+		}
+		if _, selected := opt.GetAttribute("selected"); selected {
+			return val
+		}
+	}
+	return firstValue
 }
 
 func (d *FormData) AddElement(e dom.Element) {

--- a/html/form_data.go
+++ b/html/form_data.go
@@ -62,7 +62,9 @@ func NewFormDataForm(form HTMLFormElement) *FormData {
 			}
 			switch domEl.TagName() {
 			case "SELECT":
-				formData.Append(name, NewFormDataValueString(selectValue(domEl)))
+				for _, v := range selectValues(domEl) {
+					formData.Append(name, NewFormDataValueString(v))
+				}
 			case "TEXTAREA":
 				formData.Append(name, NewFormDataValueString(domEl.TextContent()))
 			}
@@ -71,22 +73,33 @@ func NewFormDataForm(form HTMLFormElement) *FormData {
 	return formData
 }
 
-// selectValue returns the value of the first <option> carrying the "selected"
-// attribute, falling back to the first option -- which is what a browser
-// submits for a select the user never touched.
+// selectValues returns the values a <select> contributes to the form data set:
+// one entry per selected <option>, in document order.
 //
-// An option with no "value" attribute submits its text content, per
+//   - <select multiple> contributes every selected option, and nothing at all
+//     when none are selected.
+//   - A single select contributes exactly one value; with no option selected it
+//     falls back to the first option, which is what a browser submits for a
+//     select the user never touched.
+//   - A select with no options contributes nothing either way.
+//
+// An option with no "value" attribute contributes its text content, per
 // https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-value
-func selectValue(sel dom.Element) string {
+func selectValues(sel dom.Element) []string {
 	parent, ok := sel.(dom.ParentNode)
 	if !ok {
-		return ""
+		return nil
 	}
 	options, err := parent.QuerySelectorAll("option")
 	if err != nil {
-		return ""
+		return nil
 	}
-	firstValue := ""
+
+	_, multiple := sel.GetAttribute("multiple")
+
+	var selected []string
+	var firstValue string
+	var hasFirst bool
 	for i := 0; i < options.Length(); i++ {
 		opt, ok := options.Item(i).(dom.Element)
 		if !ok {
@@ -96,14 +109,24 @@ func selectValue(sel dom.Element) string {
 		if !hasVal {
 			val = opt.TextContent()
 		}
-		if i == 0 {
-			firstValue = val
+		if !hasFirst {
+			firstValue, hasFirst = val, true
 		}
-		if _, selected := opt.GetAttribute("selected"); selected {
-			return val
+		if _, isSelected := opt.GetAttribute("selected"); isSelected {
+			if !multiple {
+				return []string{val}
+			}
+			selected = append(selected, val)
 		}
 	}
-	return firstValue
+	if multiple {
+		// No fallback: an untouched multiple select submits nothing.
+		return selected
+	}
+	if !hasFirst {
+		return nil // no options at all
+	}
+	return []string{firstValue}
 }
 
 func (d *FormData) AddElement(e dom.Element) {

--- a/html/form_data_checkable_test.go
+++ b/html/form_data_checkable_test.go
@@ -1,0 +1,110 @@
+package html_test
+
+import (
+	"testing"
+
+	"github.com/gost-dom/browser/html"
+	"github.com/stretchr/testify/assert"
+)
+
+// A checked checkbox contributes its value attribute. "on" is the default for
+// a checkbox with no value, not a replacement for one -- without this, every
+// checkbox in a group submits the same string and the group is unusable.
+func TestFormDataCheckboxSubmitsItsValue(t *testing.T) {
+	form := formFromHTML(t, `<form>
+		<input type="checkbox" name="mode" value="42" checked>
+	</form>`)
+
+	formData := html.NewFormDataForm(form)
+
+	assert.Equal(t, html.FormDataValue("42"), formData.Get("mode"))
+}
+
+// A valueless checkbox keeps the "on" default.
+func TestFormDataCheckboxWithoutValueSubmitsOn(t *testing.T) {
+	form := formFromHTML(t, `<form>
+		<input type="checkbox" name="agree" checked>
+	</form>`)
+
+	formData := html.NewFormDataForm(form)
+
+	assert.Equal(t, html.FormDataValue("on"), formData.Get("agree"))
+}
+
+// Several checked checkboxes sharing a name contribute one entry each --
+// the shape a multi-select group relies on.
+func TestFormDataCheckboxGroupSubmitsEveryCheckedValue(t *testing.T) {
+	form := formFromHTML(t, `<form>
+		<input type="checkbox" name="mode" value="1" checked>
+		<input type="checkbox" name="mode" value="2">
+		<input type="checkbox" name="mode" value="3" checked>
+	</form>`)
+
+	formData := html.NewFormDataForm(form)
+
+	assert.Equal(t,
+		[]html.FormDataValue{html.FormDataValue("1"), html.FormDataValue("3")},
+		formData.GetAll("mode"),
+		"only the checked boxes contribute, each with its own value")
+}
+
+// A radio group contributes only the checked option. Previously every radio
+// was submitted regardless, so a group of three sent all three values.
+func TestFormDataRadioSubmitsOnlyTheCheckedOption(t *testing.T) {
+	form := formFromHTML(t, `<form>
+		<input type="radio" name="choice" value="a">
+		<input type="radio" name="choice" value="b" checked>
+		<input type="radio" name="choice" value="c">
+	</form>`)
+
+	formData := html.NewFormDataForm(form)
+
+	assert.Equal(t,
+		[]html.FormDataValue{html.FormDataValue("b")},
+		formData.GetAll("choice"),
+		"an unchecked radio contributes nothing")
+}
+
+// A radio group with nothing checked contributes nothing.
+func TestFormDataRadioWithNoSelectionSubmitsNothing(t *testing.T) {
+	form := formFromHTML(t, `<form>
+		<input name="username" value="john">
+		<input type="radio" name="choice" value="a">
+		<input type="radio" name="choice" value="b">
+	</form>`)
+
+	formData := html.NewFormDataForm(form)
+
+	assert.False(t, formData.Has("choice"))
+	assert.Len(t, formData.Entries, 1)
+}
+
+// Checkedness falls back to the content attribute, so a control parsed from
+// markup is seen as checked without anything calling SetChecked. This is what
+// a test driving a rendered page relies on.
+func TestFormDataCheckednessReadsTheAttribute(t *testing.T) {
+	form := formFromHTML(t, `<form>
+		<input type="checkbox" name="cb" value="yes" checked>
+		<input type="radio" name="r" value="picked" checked>
+	</form>`)
+
+	formData := html.NewFormDataForm(form)
+
+	assert.Equal(t, html.FormDataValue("yes"), formData.Get("cb"))
+	assert.Equal(t, html.FormDataValue("picked"), formData.Get("r"))
+}
+
+// Disabled checkables are still excluded.
+func TestFormDataSkipsDisabledCheckables(t *testing.T) {
+	form := formFromHTML(t, `<form>
+		<input type="checkbox" name="cb" value="1" checked disabled>
+		<input type="radio" name="r" value="a" checked disabled>
+		<input name="username" value="john">
+	</form>`)
+
+	formData := html.NewFormDataForm(form)
+
+	assert.False(t, formData.Has("cb"))
+	assert.False(t, formData.Has("r"))
+	assert.Len(t, formData.Entries, 1)
+}

--- a/html/form_data_select_textarea_test.go
+++ b/html/form_data_select_textarea_test.go
@@ -73,6 +73,79 @@ func TestFormDataFormSelectOptionWithoutValueUsesText(t *testing.T) {
 	assert.Equal(t, html.FormDataValue("Green"), formData.Get("colour"))
 }
 
+// A <select multiple> contributes one entry per selected option, in document
+// order -- not just the first.
+func TestFormDataFormMultipleSelectSubmitsEverySelectedOption(t *testing.T) {
+	form := formFromHTML(t, `<form>
+		<select name="colour" multiple>
+			<option value="red" selected>Red</option>
+			<option value="green">Green</option>
+			<option value="blue" selected>Blue</option>
+		</select>
+	</form>`)
+
+	formData := html.NewFormDataForm(form)
+
+	assert.Equal(t,
+		[]html.FormDataValue{html.FormDataValue("red"), html.FormDataValue("blue")},
+		formData.GetAll("colour"),
+		"every selected option is submitted, in document order")
+}
+
+// A <select multiple> with nothing selected submits nothing -- the
+// first-option fallback applies only to single selects.
+func TestFormDataFormMultipleSelectWithNoSelectionSubmitsNothing(t *testing.T) {
+	form := formFromHTML(t, `<form>
+		<input name="username" value="john">
+		<select name="colour" multiple>
+			<option value="red">Red</option>
+			<option value="green">Green</option>
+		</select>
+	</form>`)
+
+	formData := html.NewFormDataForm(form)
+
+	assert.False(t, formData.Has("colour"),
+		"an untouched multiple select contributes no entry")
+	assert.Len(t, formData.Entries, 1, "only the input should be submitted")
+}
+
+// A single select with one option selected still yields exactly one entry
+// even if later options exist.
+func TestFormDataFormSingleSelectSubmitsOneValue(t *testing.T) {
+	form := formFromHTML(t, `<form>
+		<select name="colour">
+			<option value="red" selected>Red</option>
+			<option value="green" selected>Green</option>
+		</select>
+	</form>`)
+
+	formData := html.NewFormDataForm(form)
+
+	assert.Equal(t,
+		[]html.FormDataValue{html.FormDataValue("red")},
+		formData.GetAll("colour"),
+		"a non-multiple select contributes a single value")
+}
+
+// A select with no options contributes nothing, rather than an empty value.
+func TestFormDataFormSelectWithNoOptionsSubmitsNothing(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		src  string
+	}{
+		{"single", `<form><input name="username" value="john"><select name="colour"></select></form>`},
+		{"multiple", `<form><input name="username" value="john"><select name="colour" multiple></select></form>`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			formData := html.NewFormDataForm(formFromHTML(t, tc.src))
+			assert.False(t, formData.Has("colour"),
+				"a select with no options contributes no entry")
+			assert.Len(t, formData.Entries, 1)
+		})
+	}
+}
+
 // Unnamed controls are skipped, matching the existing behaviour for inputs.
 func TestFormDataFormSkipsUnnamedSelectAndTextarea(t *testing.T) {
 	form := formFromHTML(t, `<form>

--- a/html/form_data_select_textarea_test.go
+++ b/html/form_data_select_textarea_test.go
@@ -110,9 +110,11 @@ func TestFormDataFormMultipleSelectWithNoSelectionSubmitsNothing(t *testing.T) {
 	assert.Len(t, formData.Entries, 1, "only the input should be submitted")
 }
 
-// A single select with one option selected still yields exactly one entry
-// even if later options exist.
-func TestFormDataFormSingleSelectSubmitsOneValue(t *testing.T) {
+// Malformed markup: a non-multiple <select> cannot legally have two selected
+// options, but nothing stops an author writing it. Browsers honour the first
+// and ignore the rest; we do the same rather than emitting two entries for a
+// control that can only hold one value.
+func TestFormDataFormSingleSelectWithTwoSelectedOptionsTakesTheFirst(t *testing.T) {
 	form := formFromHTML(t, `<form>
 		<select name="colour">
 			<option value="red" selected>Red</option>
@@ -125,7 +127,7 @@ func TestFormDataFormSingleSelectSubmitsOneValue(t *testing.T) {
 	assert.Equal(t,
 		[]html.FormDataValue{html.FormDataValue("red")},
 		formData.GetAll("colour"),
-		"a non-multiple select contributes a single value")
+		"a non-multiple select contributes exactly one value, the first selected")
 }
 
 // A select with no options contributes nothing, rather than an empty value.
@@ -144,6 +146,140 @@ func TestFormDataFormSelectWithNoOptionsSubmitsNothing(t *testing.T) {
 			assert.Len(t, formData.Entries, 1)
 		})
 	}
+}
+
+// An option's text-derived value is stripped and collapsed of ASCII
+// whitespace -- templates indent their options, and the raw text content
+// would otherwise arrive wrapped in newlines and tabs.
+func TestFormDataFormSelectCollapsesOptionTextWhitespace(t *testing.T) {
+	form := formFromHTML(t, `<form>
+		<select name="colour">
+			<option>
+				Forest   Green
+			</option>
+		</select>
+	</form>`)
+
+	formData := html.NewFormDataForm(form)
+
+	assert.Equal(t, html.FormDataValue("Forest Green"), formData.Get("colour"),
+		"leading/trailing whitespace stripped, interior runs collapsed to one space")
+}
+
+// A disabled control is barred from the form data set.
+func TestFormDataFormSkipsDisabledControls(t *testing.T) {
+	form := formFromHTML(t, `<form>
+		<input name="username" value="john">
+		<input name="nickname" value="johnny" disabled>
+		<select name="colour" disabled><option value="red" selected>Red</option></select>
+		<textarea name="comment" disabled>hello</textarea>
+	</form>`)
+
+	formData := html.NewFormDataForm(form)
+
+	assert.True(t, formData.Has("username"))
+	assert.False(t, formData.Has("nickname"), "disabled input is skipped")
+	assert.False(t, formData.Has("colour"), "disabled select is skipped")
+	assert.False(t, formData.Has("comment"), "disabled textarea is skipped")
+	assert.Len(t, formData.Entries, 1)
+}
+
+// Controls inside a disabled <fieldset> are disabled too -- except those in
+// the fieldset's first <legend>.
+func TestFormDataFormSkipsControlsInDisabledFieldset(t *testing.T) {
+	form := formFromHTML(t, `<form>
+		<fieldset disabled>
+			<legend><input name="in_legend" value="kept"></legend>
+			<input name="in_fieldset" value="dropped">
+			<select name="sel_in_fieldset"><option value="x" selected>X</option></select>
+		</fieldset>
+		<input name="outside" value="kept">
+	</form>`)
+
+	formData := html.NewFormDataForm(form)
+
+	assert.True(t, formData.Has("outside"), "control outside the fieldset is unaffected")
+	assert.True(t, formData.Has("in_legend"), "control in the first legend stays enabled")
+	assert.False(t, formData.Has("in_fieldset"), "control in a disabled fieldset is skipped")
+	assert.False(t, formData.Has("sel_in_fieldset"), "select in a disabled fieldset is skipped")
+}
+
+// An enabled fieldset disables nothing.
+func TestFormDataFormEnabledFieldsetKeepsControls(t *testing.T) {
+	form := formFromHTML(t, `<form>
+		<fieldset>
+			<legend>Details</legend>
+			<input name="username" value="john">
+		</fieldset>
+	</form>`)
+
+	formData := html.NewFormDataForm(form)
+
+	assert.Equal(t, html.FormDataValue("john"), formData.Get("username"))
+}
+
+// Disabled options can be neither selected nor used as the fallback.
+func TestFormDataFormSkipsDisabledOptions(t *testing.T) {
+	t.Run("disabled option is not the fallback", func(t *testing.T) {
+		form := formFromHTML(t, `<form>
+			<select name="colour">
+				<option value="placeholder" disabled>Choose...</option>
+				<option value="red">Red</option>
+			</select>
+		</form>`)
+
+		formData := html.NewFormDataForm(form)
+
+		assert.Equal(t, html.FormDataValue("red"), formData.Get("colour"),
+			"the disabled placeholder is skipped, so red is the first usable option")
+	})
+
+	t.Run("disabled option is not selected", func(t *testing.T) {
+		form := formFromHTML(t, `<form>
+			<select name="colour" multiple>
+				<option value="red" selected>Red</option>
+				<option value="green" selected disabled>Green</option>
+			</select>
+		</form>`)
+
+		formData := html.NewFormDataForm(form)
+
+		assert.Equal(t,
+			[]html.FormDataValue{html.FormDataValue("red")},
+			formData.GetAll("colour"),
+			"a disabled option contributes nothing even when marked selected")
+	})
+
+	t.Run("all options disabled contributes nothing", func(t *testing.T) {
+		form := formFromHTML(t, `<form>
+			<input name="username" value="john">
+			<select name="colour"><option value="red" disabled>Red</option></select>
+		</form>`)
+
+		formData := html.NewFormDataForm(form)
+
+		assert.False(t, formData.Has("colour"))
+		assert.Len(t, formData.Entries, 1)
+	})
+}
+
+// Options inside a disabled <optgroup> are disabled too.
+func TestFormDataFormSkipsOptionsInDisabledOptgroup(t *testing.T) {
+	form := formFromHTML(t, `<form>
+		<select name="colour">
+			<optgroup label="Discontinued" disabled>
+				<option value="puce">Puce</option>
+			</optgroup>
+			<optgroup label="Current">
+				<option value="red">Red</option>
+			</optgroup>
+		</select>
+	</form>`)
+
+	formData := html.NewFormDataForm(form)
+
+	assert.Equal(t, html.FormDataValue("red"), formData.Get("colour"),
+		"options in a disabled optgroup are skipped, including as the fallback")
 }
 
 // Unnamed controls are skipped, matching the existing behaviour for inputs.

--- a/html/form_data_select_textarea_test.go
+++ b/html/form_data_select_textarea_test.go
@@ -1,0 +1,109 @@
+package html_test
+
+import (
+	"testing"
+
+	"github.com/gost-dom/browser/dom"
+	"github.com/gost-dom/browser/html"
+	"github.com/gost-dom/browser/internal/testing/htmltest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// formFromHTML loads a document and returns its first <form>.
+func formFromHTML(t *testing.T, src string) html.HTMLFormElement {
+	t.Helper()
+	win := htmltest.NewWindowHelper(t, nil)
+	win.MustLoadHTML(src)
+	el, err := win.Document().QuerySelector("form")
+	require.NoError(t, err, "querying for form")
+	require.NotNil(t, el, "no form in test HTML")
+	form, ok := el.(html.HTMLFormElement)
+	require.True(t, ok, "element is not an HTMLFormElement")
+	return form
+}
+
+// The form data set must include <select> and <textarea> controls, not just
+// <input>. https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-form-data-set
+func TestFormDataFormIncludesSelectAndTextarea(t *testing.T) {
+	form := formFromHTML(t, `<form>
+		<input name="username" value="john">
+		<select name="colour">
+			<option value="red">Red</option>
+			<option value="green" selected>Green</option>
+			<option value="blue">Blue</option>
+		</select>
+		<textarea name="comment">hello world</textarea>
+	</form>`)
+
+	formData := html.NewFormDataForm(form)
+
+	assert.Equal(t, html.FormDataValue("john"), formData.Get("username"))
+	assert.Equal(t, html.FormDataValue("green"), formData.Get("colour"),
+		"select submits the option carrying the selected attribute")
+	assert.Equal(t, html.FormDataValue("hello world"), formData.Get("comment"),
+		"textarea submits its text content")
+}
+
+// With no option marked selected, a browser submits the first one.
+func TestFormDataFormSelectDefaultsToFirstOption(t *testing.T) {
+	form := formFromHTML(t, `<form>
+		<select name="colour">
+			<option value="red">Red</option>
+			<option value="green">Green</option>
+		</select>
+	</form>`)
+
+	formData := html.NewFormDataForm(form)
+
+	assert.Equal(t, html.FormDataValue("red"), formData.Get("colour"))
+}
+
+// An option without a value attribute submits its text content.
+func TestFormDataFormSelectOptionWithoutValueUsesText(t *testing.T) {
+	form := formFromHTML(t, `<form>
+		<select name="colour">
+			<option>Red</option>
+			<option selected>Green</option>
+		</select>
+	</form>`)
+
+	formData := html.NewFormDataForm(form)
+
+	assert.Equal(t, html.FormDataValue("Green"), formData.Get("colour"))
+}
+
+// Unnamed controls are skipped, matching the existing behaviour for inputs.
+func TestFormDataFormSkipsUnnamedSelectAndTextarea(t *testing.T) {
+	form := formFromHTML(t, `<form>
+		<input name="username" value="john">
+		<select><option value="red" selected>Red</option></select>
+		<textarea>orphan text</textarea>
+	</form>`)
+
+	formData := html.NewFormDataForm(form)
+
+	assert.Len(t, formData.Entries, 1, "only the named input should be submitted")
+	assert.Equal(t, html.FormDataValue("john"), formData.Get("username"))
+}
+
+// Setting the selected attribute after parse -- what a test driving a page
+// does -- must change what the form submits.
+func TestFormDataFormSelectReflectsAttributeChange(t *testing.T) {
+	form := formFromHTML(t, `<form>
+		<select name="colour">
+			<option value="red">Red</option>
+			<option value="green">Green</option>
+		</select>
+	</form>`)
+
+	opts, err := form.QuerySelectorAll("option")
+	require.NoError(t, err)
+	green, ok := opts.Item(1).(dom.Element)
+	require.True(t, ok)
+	green.SetAttribute("selected", "selected")
+
+	formData := html.NewFormDataForm(form)
+
+	assert.Equal(t, html.FormDataValue("green"), formData.Get("colour"))
+}

--- a/html/html_form_element.go
+++ b/html/html_form_element.go
@@ -103,9 +103,9 @@ func (e *htmlFormElement) Submit() error {
 }
 
 func (e *htmlFormElement) Elements() dom.NodeList {
-	inputs, err := e.QuerySelectorAll("input")
+	elements, err := e.QuerySelectorAll("input, select, textarea")
 	if err == nil {
-		return inputs
+		return elements
 	}
 	panic(err) // Should only be on invalid css pattern
 }

--- a/html/html_input_element.go
+++ b/html/html_input_element.go
@@ -37,8 +37,19 @@ func (e *htmlInputElement) Name() string {
 }
 func (e *htmlInputElement) SetName(value string) { e.SetAttribute("name", value) }
 func (e *htmlInputElement) CheckValidity() bool  { return true }
-func (e *htmlInputElement) Checked() bool        { return e.checked }
-func (e *htmlInputElement) SetChecked(b bool)    { e.checked = b }
+
+// Checked reports the control's checkedness. Like Value, it falls back to the
+// content attribute so a control parsed from markup -- <input checked> -- is
+// seen as checked without anything having called SetChecked.
+func (e *htmlInputElement) Checked() bool {
+	if e.checked {
+		return true
+	}
+	_, hasAttr := e.GetAttribute("checked")
+	return hasAttr
+}
+
+func (e *htmlInputElement) SetChecked(b bool) { e.checked = b }
 func (e *htmlInputElement) Value() string {
 	value := e.value
 	if value == "" {


### PR DESCRIPTION
Form.Elements() now matches <select> and <textarea> in addition to <input>, and NewFormDataForm extracts their values: the option carrying the "selected" attribute (or the first option as fallback) for <select>, and text content for <textarea>. These elements lack specialized DOM types, so values are read from the element directly. Without this, submitting any form containing a select or textarea silently drops those fields, so handlers see them as empty. Ran into this while using gost-dom for some integration tests on an app I'm building.  Figured I would upstream it.
